### PR TITLE
Catch errors from the services

### DIFF
--- a/lib/dartpad_server.dart
+++ b/lib/dartpad_server.dart
@@ -73,7 +73,6 @@ class DartpadServer {
   Compiler compiler;
 
   DartpadServer._(String sdkPath, this.port) {
-    // TODO: Warm up the analyzer and compiler.
     analyzer = new Analyzer(sdkPath);
     compiler = new Compiler(sdkPath);
 
@@ -113,7 +112,6 @@ Dartpad server.
 
       Stopwatch watch = new Stopwatch()..start();
 
-      // TODO: Catch an exception, return a 500 error code?
       return analyzer.analyze(source).then((AnalysisResults results) {
         List issues = results.issues.map((issue) => issue.toMap()).toList();
         String json = JSON.encode(issues);
@@ -123,6 +121,9 @@ Dartpad server.
         _logger.info('Analyzed ${lineCount} lines of Dart in ${ms}ms.');
 
         return new Response.ok(json, headers: _jsonHeader);
+      }).catchError((e, st) {
+        String errorText = 'Error during analysis: ${e}\n${st}';
+        return new Response(500, body: errorText);
       });
     });
   }
@@ -148,6 +149,9 @@ Dartpad server.
             String errors = results.problems.map(_printProblem).join('\n');
             return new Response(400, body: errors);
           }
+        }).catchError((e, st) {
+          String errorText = 'Error during compile: ${e}\n${st}';
+          return new Response(500, body: errorText);
         });
     });
   }

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -47,34 +47,38 @@ class Analyzer {
       analyze(useHtml ? sampleCodeWeb : sampleCode);
 
   Future<AnalysisResults> analyze(String source) {
-    _source.updateSource(source);
+    try {
+      _source.updateSource(source);
 
-    ChangeSet changeSet = new ChangeSet();
-    changeSet.addedSource(_source);
-    _context.applyChanges(changeSet);
-    _context.computeErrors(_source);
-    _context.getErrors(_source);
+      ChangeSet changeSet = new ChangeSet();
+      changeSet.addedSource(_source);
+      _context.applyChanges(changeSet);
+      _context.computeErrors(_source);
+      _context.getErrors(_source);
 
-    List<AnalysisErrorInfo> errorInfos = [];
+      List<AnalysisErrorInfo> errorInfos = [];
 
-    _context.computeErrors(_source);
-    errorInfos.add(_context.getErrors(_source));
+      _context.computeErrors(_source);
+      errorInfos.add(_context.getErrors(_source));
 
-    List<_Error> errors = errorInfos
-      .expand((AnalysisErrorInfo info) {
-        return info.errors.map((error) => new _Error(error, info.lineInfo));
-      })
-      .where((_Error error) => error.errorType != ErrorType.TODO)
-      .toList();
+      List<_Error> errors = errorInfos
+        .expand((AnalysisErrorInfo info) {
+          return info.errors.map((error) => new _Error(error, info.lineInfo));
+        })
+        .where((_Error error) => error.errorType != ErrorType.TODO)
+        .toList();
 
-    List<AnalysisIssue> issues = errors.map((_Error error) {
-      return new AnalysisIssue(
-          error.severityName, error.line, error.message,
-          location: error.location,
-          charStart: error.offset, charLength: error.length);
-    }).toList();
+      List<AnalysisIssue> issues = errors.map((_Error error) {
+        return new AnalysisIssue(
+            error.severityName, error.line, error.message,
+            location: error.location,
+            charStart: error.offset, charLength: error.length);
+      }).toList();
 
-    return new Future.value(new AnalysisResults(issues));
+      return new Future.value(new AnalysisResults(issues));
+    } catch (e, st) {
+      return new Future.error(e, st);
+    }
   }
 }
 

--- a/lib/src/bench.dart
+++ b/lib/src/bench.dart
@@ -89,8 +89,8 @@ class BenchMarkResult {
 
   double _averageMicroseconds() => microseconds / iteration;
 
-  String toString() => '[${_padLeft(benchmark.name, 23)}: '
-      '${_padRight(_averageMilliseconds().toStringAsFixed(3), 8)}ms]';
+  String toString() => '[${benchmark.name.padRight(23)}: '
+      '${_averageMilliseconds().toStringAsFixed(3).padLeft(8)}ms]';
 }
 
 bool isCheckedMode() {
@@ -104,28 +104,3 @@ bool isCheckedMode() {
 }
 
 dynamic get _intVal => 1 + 2;
-
-String _padLeft(String str, int cols) =>
-    (str.length < cols) ? str + _spaces(cols - str.length) : str;
-
-String _padRight(String str, int cols) =>
-    (str.length < cols) ? _spaces(cols - str.length) + str : str;
-
-String _spaces(int count) {
-  assert(count >= 0);
-  switch (count) {
-    case 0 : return '';
-    case 1 : return ' ';
-    case 2 : return '  ';
-    case 3 : return '   ';
-    case 4 : return '    ';
-    case 5 : return '     ';
-    case 6 : return '      ';
-    case 7 : return '       ';
-    case 8 : return '        ';
-    case 9 : return '         ';
-    case 10 : return '          ';
-    default :
-      return _spaces(10) + _spaces(count - 10);
-  }
-}

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -33,6 +33,7 @@ class Lines {
 
   /// Return the 0-based line number.
   int getLineForOffset(int offset) {
+    assert(offset != null);
     for (int i = 0; i < _starts.length; i++) {
       if (offset <= _starts[i]) return i;
     }

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -110,7 +110,7 @@ class CompilationProblem implements Comparable {
 
   CompilationProblem._(this.uri, this.begin, this.end, this.message,
       this._diagnostic, Lines lines) {
-    _line = lines.getLineForOffset(begin) + 1;
+    _line = begin == null ? 0 : lines.getLineForOffset(begin) + 1;
   }
 
   /// The 1-based line number.


### PR DESCRIPTION
Catch errors from the analysis and compiler services; return them as 500 http errors (with the proper CORS headers).

Before, exceptions from the server either wouldn't be reported to the client, or would be returned as http errors, but without the proper CORS header, so the client couldn't read the response.

@lukechurch 
