### PR TITLE
Replace memcache key with SHA hash of the source, Logging improvements

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   appengine: '>=0.2.1 <0.3.0'
   args: any
   compiler_unsupported: 1.9.0-dev.2.2
+  crypto: any
   grinder: '>=0.6.4 <0.7.0'
   logging: any
   shelf: any
@@ -20,7 +21,6 @@ dependencies:
 dev_dependencies:
   browser: any
   codemirror: '>=0.1.0 <0.2.0'
-  crypto: any
   http: any
   unittest: any
 


### PR DESCRIPTION
Memcache keys are pretty size restricted, so we should be hashing the source before trying to use it.

If we're feeling extremely paranoid, we could store the source as well as the result in the memcache-value so the extremely rare hash collisions didn't cause a problem. This isn't needed for now.
- Increase the logging for UX and error traceability analysis by adding the POST data so we can do a full replay.

@devoncarew 
