### PR TITLE
add a build task to generate the discovery document from the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ To run the server, run:
 The server will run from port 8082 and export several JSON APIs, like
 `/api/compile` and `/api/analyze`.
 
+## The API
+
+The discovery doc for the server's REST API is available here:
+http://dart-services.appspot.com/api/discovery/v1/apis/dartservices/v1/rest.
+
 ## See also
 
 The [Dart Pad](https://github.com/dart-lang/dart-pad) repo.

--- a/doc/dartservices.json
+++ b/doc/dartservices.json
@@ -1,0 +1,220 @@
+{
+ "kind": "discovery#restDescription",
+ "etag": "f0c37e3991119bf8abfe2c1625b5779a389c2bd5",
+ "discoveryVersion": "v1",
+ "id": "dartservices:v1",
+ "name": "dartservices",
+ "version": "v1",
+ "revision": "0",
+ "protocol": "rest",
+ "baseUrl": "http://localhost:9090/api/dartservices/v1/",
+ "basePath": "/api/dartservices/v1/",
+ "rootUrl": "http://localhost:9090/",
+ "servicePath": "api/dartservices/v1/",
+ "parameters": {},
+ "schemas": {
+  "SourceRequest": {
+   "id": "SourceRequest",
+   "type": "object",
+   "properties": {
+    "source": {
+     "type": "string",
+     "required": true
+    },
+    "offset": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  },
+  "AnalysisResults": {
+   "id": "AnalysisResults",
+   "type": "object",
+   "properties": {
+    "issues": {
+     "type": "array",
+     "items": {
+      "$ref": "AnalysisIssue"
+     }
+    }
+   }
+  },
+  "AnalysisIssue": {
+   "id": "AnalysisIssue",
+   "type": "object",
+   "properties": {
+    "kind": {
+     "type": "string"
+    },
+    "line": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "message": {
+     "type": "string"
+    },
+    "charStart": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "charLength": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "location": {
+     "type": "string"
+    }
+   }
+  },
+  "CompileResponse": {
+   "id": "CompileResponse",
+   "type": "object",
+   "properties": {
+    "result": {
+     "type": "string"
+    }
+   }
+  },
+  "DocumentResponse": {
+   "id": "DocumentResponse",
+   "type": "object",
+   "properties": {
+    "info": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    }
+   }
+  }
+ },
+ "methods": {
+  "analyze": {
+   "id": "CommonServer.analyze",
+   "path": "analyze",
+   "httpMethod": "POST",
+   "parameters": {},
+   "parameterOrder": [],
+   "request": {
+    "$ref": "SourceRequest"
+   },
+   "response": {
+    "$ref": "AnalysisResults"
+   }
+  },
+  "analyzeGet": {
+   "id": "CommonServer.analyzeGet",
+   "path": "analyze",
+   "httpMethod": "GET",
+   "parameters": {
+    "source": {
+     "type": "string",
+     "description": "Query parameter: 'source'.",
+     "required": false,
+     "location": "query"
+    }
+   },
+   "parameterOrder": [],
+   "response": {
+    "$ref": "AnalysisResults"
+   }
+  },
+  "compile": {
+   "id": "CommonServer.compile",
+   "path": "compile",
+   "httpMethod": "POST",
+   "parameters": {},
+   "parameterOrder": [],
+   "request": {
+    "$ref": "SourceRequest"
+   },
+   "response": {
+    "$ref": "CompileResponse"
+   }
+  },
+  "compileGet": {
+   "id": "CommonServer.compileGet",
+   "path": "compile",
+   "httpMethod": "GET",
+   "parameters": {
+    "source": {
+     "type": "string",
+     "description": "Query parameter: 'source'.",
+     "required": false,
+     "location": "query"
+    }
+   },
+   "parameterOrder": [],
+   "response": {
+    "$ref": "CompileResponse"
+   }
+  },
+  "complete": {
+   "id": "CommonServer.complete",
+   "path": "complete",
+   "httpMethod": "POST",
+   "parameters": {},
+   "parameterOrder": [],
+   "request": {
+    "$ref": "SourceRequest"
+   }
+  },
+  "completeGet": {
+   "id": "CommonServer.completeGet",
+   "path": "complete",
+   "httpMethod": "GET",
+   "parameters": {
+    "source": {
+     "type": "string",
+     "description": "Query parameter: 'source'.",
+     "required": false,
+     "location": "query"
+    },
+    "offset": {
+     "type": "integer",
+     "description": "Query parameter: 'offset'.",
+     "required": false,
+     "location": "query"
+    }
+   },
+   "parameterOrder": []
+  },
+  "document": {
+   "id": "CommonServer.document",
+   "path": "document",
+   "httpMethod": "POST",
+   "parameters": {},
+   "parameterOrder": [],
+   "request": {
+    "$ref": "SourceRequest"
+   },
+   "response": {
+    "$ref": "DocumentResponse"
+   }
+  },
+  "documentGet": {
+   "id": "CommonServer.documentGet",
+   "path": "document",
+   "httpMethod": "GET",
+   "parameters": {
+    "source": {
+     "type": "string",
+     "description": "Query parameter: 'source'.",
+     "required": false,
+     "location": "query"
+    },
+    "offset": {
+     "type": "integer",
+     "description": "Query parameter: 'offset'.",
+     "required": false,
+     "location": "query"
+    }
+   },
+   "parameterOrder": [],
+   "response": {
+    "$ref": "DocumentResponse"
+   }
+  }
+ },
+ "resources": {}
+}

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -7,9 +7,9 @@
  "version": "v1",
  "revision": "0",
  "protocol": "rest",
- "baseUrl": "http://localhost:9090/api/dartservices/v1/",
+ "baseUrl": "http://localhost/api/dartservices/v1/",
  "basePath": "/api/dartservices/v1/",
- "rootUrl": "http://localhost:9090/",
+ "rootUrl": "http://localhost/",
  "servicePath": "api/dartservices/v1/",
  "parameters": {},
  "schemas": {

--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -10,6 +10,7 @@ import 'dart:io' as io;
 import 'package:appengine/appengine.dart';
 import 'package:memcache/memcache.dart';
 import 'package:rpc/rpc.dart';
+
 import 'src/common_server.dart';
 
 Logging get logging => context.services.logging;

--- a/lib/services_server.dart
+++ b/lib/services_server.dart
@@ -10,16 +10,17 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:grinder/grinder.dart' as grinder;
 import 'package:logging/logging.dart';
+import 'package:rpc/rpc.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf;
 import 'package:shelf_route/shelf_route.dart';
-import 'package:rpc/rpc.dart';
+
 import 'src/common_server.dart';
 
 const Map _textPlainHeader = const {HttpHeaders.CONTENT_TYPE: 'text/plain'};
 const Map _jsonHeader = const {HttpHeaders.CONTENT_TYPE: 'application/json'};
 
-Logger _logger = new Logger('endpoints');
+Logger _logger = new Logger('services');
 
 void main(List<String> args) {
   var parser = new ArgParser();
@@ -106,16 +107,9 @@ class EndpointsServer {
 
   Response printUsage(Request request) {
     return new Response.ok('''
-Dart Endpoints server.
+Dart Services server
 
-POST /api/dartServices/v1/analyze  - Send Dart source as JSON to this URL and get JSON errors and warnings back.
-GET  /api/dartServices/v1/analyze  - Send Dart source to this URL as url query string and get JSON errors and warnings back.
-POST /api/dartServices/v1/compile  - Send Dart source as JSON to this URL and get compiled results back.
-GET  /api/dartServices/v1/compile  - Send Dart source to this URL as url query string and compiled results back.
-POST /api/dartServices/v1/complete - TODO:
-GET  /api/dartServices/v1/complete - TODO:
-POST /api/dartServices/v1/document - Send Dart source as JSON (source, offset) to the URL to calculate dartdoc.
-GET  /api/dartServices/v1/document - Send Dart source to this URL as url query string (source, offset) to calculate dartdoc.
+View the available API calls at /api/discovery/v1/apis/dartservices/v1/rest.
 ''');
   }
 


### PR DESCRIPTION
Fix #54 - generate the discovery document as part of our build.

@lukechurch, @wibling 

@wibling, what I'm doing now is starting a copy of the server, downloading the discovery document from the localhost URL, writing the file out, and killing the server. Would there be a more straightforward way of doing this? I imagine you need the annotations available at runtime to generate the doc. If the server could respond to a `--gen_doc` command-line flag, are there APIs in the `rpc` package the server could call to generate the doc w/o having to have a server running? As in, the server could either be invoked in a way to start up a server (the 99% use case), or invoked such that it just wrote out its discovery doc and exited?