### PR TITLE
Migrate source storage to explicit schema in the datastore

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-version: logger
+version: logger-db
 runtime: custom
 vm: true
 api_version: 1
@@ -6,6 +6,13 @@ api_version: 1
 resources:
   cpu: 2
   memory_gb: 3
+
+automatic_scaling:
+  min_num_instances: 3
+  max_num_instances: 20
+  cool_down_period_sec: 60
+  cpu_utilization:
+    target_utilization: 0.5
 
 env_variables:
       DART_VM_OPTIONS: --enable-async

--- a/lib/services_server.dart
+++ b/lib/services_server.dart
@@ -53,6 +53,7 @@ void main(List<String> args) {
     });
     return;
   }
+  _logger.level = Level.ALL;
 
   Logger.root.onRecord.listen((r) => print(r));
 
@@ -74,7 +75,7 @@ class EndpointsServer {
 
   static Future<String> generateDiscovery(String sdkPath,
                                           String serverUrl) async {
-    var commonServer = new CommonServer(sdkPath, new _Cache());
+    var commonServer = new CommonServer(sdkPath, new _Cache(), new _Recorder());
     var apiServer =
         new ApiServer('/api', prettyPrint: true)..addApi(commonServer);
     apiServer.enableDiscoveryApi(serverUrl);
@@ -99,7 +100,7 @@ class EndpointsServer {
 
   EndpointsServer._(String sdkPath, this.port) {
     discoveryEnabled = false;
-    commonServer = new CommonServer(sdkPath, new _Cache());
+    commonServer = new CommonServer(sdkPath, new _Cache(), new _Recorder());
     apiServer = new ApiServer('/api', prettyPrint: true)..addApi(commonServer);
 
     pipeline = new Pipeline()
@@ -154,4 +155,13 @@ class _Cache implements ServerCache {
   Future set(String key, String value, {Duration expiration}) =>
       new Future.value();
   Future remove(String key) => new Future.value();
+}
+
+class _Recorder implements SourceRequestRecorder {
+  
+  @override
+  Future record(String verb, String source, [int offset = -99]) {
+    _logger.fine("$verb, $offset, $source");
+    return new Future.value();
+  }
 }

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -18,6 +18,7 @@ void defineTests() {
   ApiServer apiServer;
 
   MockCache cache = new MockCache();
+  MockRequestRecorder recorder = new MockRequestRecorder();
 
   Future<HttpApiResponse> _sendPostRequest(String path, json) {
     assert(apiServer != null);
@@ -30,7 +31,7 @@ void defineTests() {
     setUp(() {
       if (server == null) {
         String sdkPath = grinder.getSdkDir().path;
-        server = new CommonServer(sdkPath, cache);
+        server = new CommonServer(sdkPath, cache, recorder);
         apiServer = new ApiServer('/api', prettyPrint: true)..addApi(server);
       }
     });
@@ -140,4 +141,12 @@ class MockCache implements ServerCache {
   Future set(String key, String value, {Duration expiration}) =>
       new Future.value();
   Future remove(String key) => new Future.value();
+}
+
+class MockRequestRecorder implements SourceRequestRecorder {
+  
+  @override
+  Future record(String verb, String source, [int offset]) {
+    return new Future.value();
+  }
 }

--- a/tool/load_driver.dart
+++ b/tool/load_driver.dart
@@ -7,10 +7,10 @@ import 'dart:async';
 import 'package:http/http.dart' as http;
 
 const POST_PAYLOAD =
-r'''{"source":"void main() {\n  for (int i = 0; i < 4; i++) {\n    print('hello ${i}');\n }\n}\n''';
-const EPILOGUE = '\n"}';
+r'''{"source": "import 'dart:html'; void main() {var count = querySelector('#count');for (int i = 0; i < 4; i++) {count.text = '${i}';print('hello ${i}');}}''';
+const EPILOGUE = '"}';
 
-const URI = "http://rpc-test.dart-services.appspot.com/api/dartservices/v1/analyze";
+const URI = "https://dart-services.appspot.com/api/dartservices/v1/compile";
 
 int count = 0;
 
@@ -23,7 +23,7 @@ void main(List<String> args) {
     qps = 1;
   }
 
-  print("QPS: $qps");
+  print("QPS: $qps, URI: $URI");
 
   int ms = (1000 / qps).floor();
   new Timer.periodic(
@@ -34,15 +34,18 @@ void main(List<String> args) {
 pingServer(Timer t) {
   count++;
 
-  if (count > 25000) {
+  if (count > 1000) {
     t.cancel();
+    return;
   }
 
   Stopwatch sw = new Stopwatch()..start();
 
   int time = new DateTime.now().millisecondsSinceEpoch;
-  http.post(Uri.parse(URI),
-      body: '$POST_PAYLOAD //$time $EPILOGUE').then((response) {
-    print(sw.elapsedMilliseconds);
+  
+  String message = '$POST_PAYLOAD //$time $EPILOGUE';
+  print(message);
+  http.post(Uri.parse(URI), body: message).then((response) {
+    print("${response.statusCode}, ${sw.elapsedMilliseconds}");
   });
 }


### PR DESCRIPTION
As per privacy design and https://github.com/dart-lang/dart-services/issues/50

Separate out how we are storing source from the normal server log channels. This makes it easier to audit the schema of the data and to keep operations data separated.

Also adjust the load tester to use dart:html libraries which stress the compiler more intensively.

FYI @devoncarew @sethladd @danrubel