### PR TITLE
Switch from String -> Blob

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-version: logger-db
+version: dbtext
 runtime: custom
 vm: true
 api_version: 1


### PR DESCRIPTION
String properties on AppEngine don't support more than 500 chars.

Switching to a compressed storage property that is more suitable, under normal conditions this will provide well in excess of a million chars.