### PR TITLE
support async await

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -195,6 +195,8 @@ class AnalysisIssue implements Comparable {
   }
 
   int compareTo(AnalysisIssue other) => line - other.line;
+
+  String toString() => '${kind}: ${message} [${line}]';
 }
 
 /// An implementation of [Source] that is based on an in-memory string.
@@ -240,15 +242,19 @@ class _StringSource implements Source {
 
   Uri resolveRelativeUri(Uri relativeUri) =>
       throw new AnalysisException("Cannot resolve a URI: ${relativeUri}");
+
+  Source get source => this;
 }
 
 class _Logger extends engine.Logger {
-  void logError(String message) => _logger.severe(message);
+  void logError(String message, [CaughtException exception]) {
+    _logger.severe(message);
+  }
 
   void logError2(String message, dynamic exception) =>
       _logger.severe(message, exception);
 
-  void logInformation(String message) { }
+  void logInformation(String message, [CaughtException exception]) { }
 
   void logInformation2(String message, dynamic exception) { }
 }

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -19,6 +19,17 @@ void main() {
 }
 """;
 
+final String sampleCodeAsync = """
+import 'dart:html';
+
+main() async {
+  print("hello");
+  querySelector('#foo').text = 'bar';
+  var foo = await HttpRequest.getString('http://www.google.com');
+  print(foo);
+}
+""";
+
 final String sampleCodeError = """
 void main() {
   print("hello")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,11 +6,11 @@ homepage: https://github.com/dart-lang/dart-services
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.22.4 <0.23.0'
+  analyzer: ^0.24.0
   appengine: '>=0.2.6 <0.3.0'
   args: ^0.12.0
   # `compiler_unsupported` needs to be pegged to a specific version.
-  compiler_unsupported: 1.9.0-dev.2.2.1
+  compiler_unsupported: 1.9.0-dev.10.4
   crypto: '>=0.9.0 <0.10.0'
   grinder: '>=0.6.4 <0.7.0'
   librato: '>=0.0.1 <0.1.0'

--- a/test/analyzer_test.dart
+++ b/test/analyzer_test.dart
@@ -31,6 +31,12 @@ void defineTests() {
       });
     });
 
+    test('async', () {
+      return analyzer.analyze(sampleCodeAsync).then((AnalysisResults results) {
+        expect(results.issues, isEmpty);
+      });
+    });
+
     test('errors', () {
       return analyzer.analyze(sampleCodeError).then((AnalysisResults results) {
         expect(results.issues.length, 1);

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -79,9 +79,10 @@ void defineTests() {
       expect(response.status, 400);
       var data = JSON.decode(UTF8.decode(await response.body.first));
       expect(data, isNotEmpty);
-      expect(data['error']['message'], "Compilation failed with errors: "
-          "[error, line 2] Expected ';' after this.");
+      expect(data['error']['message'],
+          contains('failed with errors: [error, line 2] Expected'));
     });
+
     /* XXX: Disabled below tests as they are causing the dart vm to crash.
     test('complete', () async {
       var json = {'source': 'void main() {print("foo");}', 'offset': 1};
@@ -144,7 +145,7 @@ class MockCache implements ServerCache {
 }
 
 class MockRequestRecorder implements SourceRequestRecorder {
-  
+
   @override
   Future record(String verb, String source, [int offset]) {
     return new Future.value();

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -31,6 +31,12 @@ void defineTests() {
       });
     });
 
+    test('web async', () {
+      return compiler.compile(sampleCodeAsync).then((CompilationResults result) {
+        expect(result.success, true);
+      });
+    });
+
     test('errors', () {
       return compiler.compile(sampleCodeError).then((CompilationResults result) {
         expect(result.success, false);


### PR DESCRIPTION
- Upgrade the analyzer and dart2js versions to capture support for async await (fix https://github.com/dart-lang/dart-services/issues/51).
- add async tests for both the analyzer and dart2js
- fix some API deltas

@lukechurch 
