### PR TITLE
fix an exception with logging

### DIFF
--- a/bin/server.dart
+++ b/bin/server.dart
@@ -6,4 +6,4 @@
 
 import 'package:services/services_gae.dart' as server;
 
-void main() => server.main();
+void main(List<String> args) => server.main();

--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -21,6 +21,7 @@ const String _API = '/api';
 final Logger _logger = new Logger('gae_server');
 
 void main() {
+  // TODO: Use the cli_util package to locate the SDK? Or depend on a CLI arg?
   GaeServer server = new GaeServer('/usr/lib/dart');
 
   // Change the log level to get more or less detailed logging.

--- a/lib/services_server.dart
+++ b/lib/services_server.dart
@@ -9,7 +9,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:grinder/grinder.dart' as grinder;
+import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:logging/logging.dart';
 import 'package:rpc/rpc.dart';
 import 'package:shelf/shelf.dart';
@@ -37,7 +37,7 @@ void main(List<String> args) {
     exit(1);
   });
 
-  Directory sdkDir = grinder.getSdkDir(args);
+  Directory sdkDir = cli_util.getSdkDir(args);
   if (sdkDir == null) {
     stdout.writeln(
         "Could not locate the SDK; "
@@ -53,8 +53,8 @@ void main(List<String> args) {
     });
     return;
   }
-  _logger.level = Level.ALL;
 
+  Logger.root.level = Level.ALL;
   Logger.root.onRecord.listen((r) => print(r));
 
   EndpointsServer.serve(sdkDir.path, port).then((EndpointsServer server) {
@@ -158,8 +158,6 @@ class _Cache implements ServerCache {
 }
 
 class _Recorder implements SourceRequestRecorder {
-  
-  @override
   Future record(String verb, String source, [int offset = -99]) {
     _logger.fine("$verb, $offset, $source");
     return new Future.value();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   analyzer: '>=0.22.4 <0.23.0'
   appengine: '>=0.2.6 <0.3.0'
   args: ^0.12.0
+  cli_util: ^0.0.1
   # `compiler_unsupported` needs to be pegged to a specific version.
   compiler_unsupported: 1.9.0-dev.2.2.1
   crypto: '>=0.9.0 <0.10.0'


### PR DESCRIPTION
- use the `cli_util` package to locate the SDK instead of `grinder`
- fix an exception with setting the logging level in the non-AE version of the server

@lukechurch 