### PR TITLE
return all the completion data available as a map

### DIFF
--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "67cad34af5b4b64436452aef9eaa91fcf9b1a3cb",
+ "etag": "13679ea51ed6f29880123385839fcd300c3496f2",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -79,8 +79,14 @@
    "id": "CompleteResponse",
    "type": "object",
    "properties": {
-    "result": {
-     "type": "string"
+    "completions": {
+     "type": "array",
+     "items": {
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     }
     }
    }
   },

--- a/doc/generated/v1.dart
+++ b/doc/generated/v1.dart
@@ -476,21 +476,21 @@ class CompileResponse {
 /** Not documented yet. */
 class CompleteResponse {
   /** Not documented yet. */
-  core.String result;
+  core.List<core.Map<core.String, core.String>> completions;
 
 
   CompleteResponse();
 
   CompleteResponse.fromJson(core.Map _json) {
-    if (_json.containsKey("result")) {
-      result = _json["result"];
+    if (_json.containsKey("completions")) {
+      completions = _json["completions"];
     }
   }
 
   core.Map toJson() {
     var _json = new core.Map();
-    if (result != null) {
-      _json["result"] = result;
+    if (completions != null) {
+      _json["completions"] = completions;
     }
     return _json;
   }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -27,7 +27,9 @@ discovery(GrinderContext context) {
   ProcessResult result = Process.runSync(
       'dart', ['bin/services.dart', '--discovery']);
 
-  if (result.exitCode != 0) throw 'Error generating the discovery document';
+  if (result.exitCode != 0) {
+    throw 'Error generating the discovery document\n${result.stderr}';
+  }
 
   File discoveryFile = new File('doc/generated/dartservices.json');
   discoveryFile.parent.createSync();


### PR DESCRIPTION
@lukechurch 

Change the /completions endpoint to return a list of maps rather than a list of strings. This includes all the completion data available from the analysis server. We'll need to update the UI fairly soon after this lands :)