### PR TITLE
return the replacement offset and length

### DIFF
--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "13679ea51ed6f29880123385839fcd300c3496f2",
+ "etag": "9406bbd71d3611efb3691e4d0fd51f8ac9dbe4a4",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -79,6 +79,16 @@
    "id": "CompleteResponse",
    "type": "object",
    "properties": {
+    "replacementOffset": {
+     "type": "integer",
+     "description": "The offset of the start of the text to be replaced.",
+     "format": "int32"
+    },
+    "replacementLength": {
+     "type": "integer",
+     "description": "The length of the text to be replaced.",
+     "format": "int32"
+    },
     "completions": {
      "type": "array",
      "items": {

--- a/doc/generated/v1.dart
+++ b/doc/generated/v1.dart
@@ -478,6 +478,12 @@ class CompleteResponse {
   /** Not documented yet. */
   core.List<core.Map<core.String, core.String>> completions;
 
+  /** The length of the text to be replaced. */
+  core.int replacementLength;
+
+  /** The offset of the start of the text to be replaced. */
+  core.int replacementOffset;
+
 
   CompleteResponse();
 
@@ -485,12 +491,24 @@ class CompleteResponse {
     if (_json.containsKey("completions")) {
       completions = _json["completions"];
     }
+    if (_json.containsKey("replacementLength")) {
+      replacementLength = _json["replacementLength"];
+    }
+    if (_json.containsKey("replacementOffset")) {
+      replacementOffset = _json["replacementOffset"];
+    }
   }
 
   core.Map toJson() {
     var _json = new core.Map();
     if (completions != null) {
       _json["completions"] = completions;
+    }
+    if (replacementLength != null) {
+      _json["replacementLength"] = replacementLength;
+    }
+    if (replacementOffset != null) {
+      _json["replacementOffset"] = replacementOffset;
     }
     return _json;
   }

--- a/lib/src/completer_driver.dart
+++ b/lib/src/completer_driver.dart
@@ -126,6 +126,7 @@ void dispatchNotification(String event, params) {
     _onServerStatus.add(true);
   }
 
+  // TODO: Should we be ignoring the ones that aren't marked 'isLast'?
   if (event == "completion.results" && params["isLast"]) {
     _onCompletionResults.add(params);
   }
@@ -141,8 +142,7 @@ Future<ServerGetVersionResult> sendServerGetVersion() {
 Future<CompletionGetSuggestionsResult> sendCompletionGetSuggestions(
     String file, int offset) {
   var params = new CompletionGetSuggestionsParams(file, offset).toJson();
-  return server.send("completion.getSuggestions", params)
-      .then((result) {
+  return server.send("completion.getSuggestions", params).then((result) {
     ResponseDecoder decoder = new ResponseDecoder(null);
     return new CompletionGetSuggestionsResult.fromJson(decoder, 'result', result);
   });
@@ -166,14 +166,15 @@ Future<AnalysisUpdateContentResult> sendAddOverlay(
 }
 
 Future sendServerShutdown() {
-  return server.send("server.shutdown", null)
-      .then((result) {
+  return server.send("server.shutdown", null).then((result) {
     return null;
   });
 }
 
-Future sendAnalysisSetAnalysisRoots(List<String> included, List<String> excluded, {Map<String, String> packageRoots}) {
-  var params = new AnalysisSetAnalysisRootsParams(included, excluded, packageRoots: packageRoots).toJson();
+Future sendAnalysisSetAnalysisRoots(List<String> included, List<String> excluded,
+    {Map<String, String> packageRoots}) {
+  var params = new AnalysisSetAnalysisRootsParams(
+      included, excluded, packageRoots: packageRoots).toJson();
   return server.send("analysis.setAnalysisRoots", params);
 }
 
@@ -327,8 +328,8 @@ class Server {
     // This will only work if the caller has already subscribed to
     // SERVER_STATUS (e.g. using sendServerSetSubscriptions(['STATUS']))
     subscription = analysisComplete.listen((bool p) {
-        completer.complete(p);
-        subscription.cancel();
+      completer.complete(p);
+      subscription.cancel();
     });
     return completer.future;
   }
@@ -342,7 +343,6 @@ class Server {
    * error response, the future will be completed with an error.
    */
   Future send(String method, Map<String, dynamic> params) {
-
     serverLog.writeln("Server.send $method $params");
 
     String id = '${_nextId++}';
@@ -380,7 +380,6 @@ class Server {
 
     String serverPath =
         normalize(join(dirname(io.Platform.script.toFilePath()), 'analysis_server_server.dart'));
-
  */
 
     List<String> arguments = [];
@@ -458,7 +457,6 @@ class Server {
       fail('Bad data received from server');
     }));
   */
-
   }
 
   /**


### PR DESCRIPTION
@lukechurch 

- return the replacementOffset and replacementLength for code completion results
- escape Maps and Lists in the cc results, instead of converting to strings. In the future we could move to a more structured type for individual cc results.
- ws changes and re-gen the discovery library