### PR TITLE
Add support for counters

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-version: cc-map
+version: cc-counter
 runtime: custom
 vm: true
 api_version: 1

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "9406bbd71d3611efb3691e4d0fd51f8ac9dbe4a4",
+ "etag": "8bcaf7f48fb21b5334e009955c1050f8c222f8c7",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -13,6 +13,16 @@
  "servicePath": "api/dartservices/v1/",
  "parameters": {},
  "schemas": {
+  "CounterResponse": {
+   "id": "CounterResponse",
+   "type": "object",
+   "properties": {
+    "count": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  },
   "SourceRequest": {
    "id": "SourceRequest",
    "type": "object",
@@ -114,6 +124,23 @@
   }
  },
  "methods": {
+  "counterGet": {
+   "id": "CommonServer.counterGet",
+   "path": "counter",
+   "httpMethod": "GET",
+   "parameters": {
+    "name": {
+     "type": "string",
+     "description": "Query parameter: 'name'.",
+     "required": false,
+     "location": "query"
+    }
+   },
+   "parameterOrder": [],
+   "response": {
+    "$ref": "CounterResponse"
+   }
+  },
   "analyze": {
    "id": "CommonServer.analyze",
    "path": "analyze",

--- a/doc/generated/v1.dart
+++ b/doc/generated/v1.dart
@@ -270,6 +270,46 @@ class DartservicesApi {
   /**
    * Not documented yet.
    *
+   * Request parameters:
+   *
+   * [name] - Query parameter: 'name'.
+   *
+   * Completes with a [CounterResponse].
+   *
+   * Completes with a [commons.ApiRequestError] if the API endpoint returned an
+   * error.
+   *
+   * If the used [http.Client] completes with an error when making a REST call,
+   * this method  will complete with the same error.
+   */
+  async.Future<CounterResponse> counterGet({core.String name}) {
+    var _url = null;
+    var _queryParams = new core.Map();
+    var _uploadMedia = null;
+    var _uploadOptions = null;
+    var _downloadOptions = commons.DownloadOptions.Metadata;
+    var _body = null;
+
+    if (name != null) {
+      _queryParams["name"] = [name];
+    }
+
+
+    _url = 'counter';
+
+    var _response = _requester.request(_url,
+                                       "GET",
+                                       body: _body,
+                                       queryParams: _queryParams,
+                                       uploadOptions: _uploadOptions,
+                                       uploadMedia: _uploadMedia,
+                                       downloadOptions: _downloadOptions);
+    return _response.then((data) => new CounterResponse.fromJson(data));
+  }
+
+  /**
+   * Not documented yet.
+   *
    * [request] - The metadata request object.
    *
    * Request parameters:
@@ -509,6 +549,30 @@ class CompleteResponse {
     }
     if (replacementOffset != null) {
       _json["replacementOffset"] = replacementOffset;
+    }
+    return _json;
+  }
+}
+
+
+/** Not documented yet. */
+class CounterResponse {
+  /** Not documented yet. */
+  core.int count;
+
+
+  CounterResponse();
+
+  CounterResponse.fromJson(core.Map _json) {
+    if (_json.containsKey("count")) {
+      count = _json["count"];
+    }
+  }
+
+  core.Map toJson() {
+    var _json = new core.Map();
+    if (count != null) {
+      _json["count"] = count;
     }
     return _json;
   }

--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -17,6 +17,7 @@ import 'package:rpc/rpc.dart' as rpc;
 import 'src/common_server.dart';
 
 import 'src/completer_driver.dart' as completer;
+import 'src/sharded_counter.dart' as counter;
 
 const String _API = '/api';
 
@@ -45,7 +46,11 @@ class GaeServer {
     _logger.level = Level.ALL;
 
     discoveryEnabled = false;
-    commonServer = new CommonServer(sdkPath, new GaeCache(), new GaeSourceRequestRecorder());
+    commonServer = new CommonServer(
+        sdkPath,
+        new GaeCache(),
+        new GaeSourceRequestRecorder(),
+        new GaeCounter());
     // Enabled pretty printing of returned json for debuggability.
     apiServer =
         new rpc.ApiServer(_API, prettyPrint: true)..addApi(commonServer);
@@ -123,6 +128,18 @@ class GaeSourceRequestRecorder implements SourceRequestRecorder {
         ms, verb, source, offset);
 
     return db.dbService.commit(inserts: [record]);
+  }
+}
+
+class GaeCounter implements PersistentCounter {
+  @override
+  Future<int> getTotal(String name) {
+    return counter.Counter.getTotal(name);
+  }
+
+  @override
+  Future increment(String name, {int increment}) {
+    return counter.Counter.increment(name);
   }
 }
 

--- a/lib/services_server.dart
+++ b/lib/services_server.dart
@@ -75,7 +75,11 @@ class EndpointsServer {
 
   static Future<String> generateDiscovery(String sdkPath,
                                           String serverUrl) async {
-    var commonServer = new CommonServer(sdkPath, new _Cache(), new _Recorder());
+    var commonServer = new CommonServer(
+        sdkPath,
+        new _Cache(),
+        new _Recorder(),
+        new _Counter());
     var apiServer =
         new ApiServer('/api', prettyPrint: true)..addApi(commonServer);
     apiServer.enableDiscoveryApi(serverUrl);
@@ -100,7 +104,11 @@ class EndpointsServer {
 
   EndpointsServer._(String sdkPath, this.port) {
     discoveryEnabled = false;
-    commonServer = new CommonServer(sdkPath, new _Cache(), new _Recorder());
+    commonServer = new CommonServer(
+        sdkPath,
+        new _Cache(),
+        new _Recorder(),
+        new _Counter());
     apiServer = new ApiServer('/api', prettyPrint: true)..addApi(commonServer);
 
     pipeline = new Pipeline()
@@ -160,6 +168,28 @@ class _Cache implements ServerCache {
 class _Recorder implements SourceRequestRecorder {
   Future record(String verb, String source, [int offset = -99]) {
     _logger.fine("$verb, $offset, $source");
+    return new Future.value();
+  }
+}
+
+/**
+ * This is a mock implementation of a counter, it doesn't use
+ * a proper persistent store.
+ */
+class _Counter implements PersistentCounter {
+  final Map<String, int> _map = {};
+
+  @override
+  Future<int> getTotal(String name) {
+    _map.putIfAbsent(name, () => 0);
+
+    return new Future.value(_map[name]);
+  }
+
+  @override
+  Future increment(String name, {int increment : 1}) {
+    _map.putIfAbsent(name, () => 0);
+    _map[name]++;
     return new Future.value();
   }
 }

--- a/lib/src/completer_driver.dart
+++ b/lib/src/completer_driver.dart
@@ -126,7 +126,8 @@ void dispatchNotification(String event, params) {
     _onServerStatus.add(true);
   }
 
-  // TODO: Should we be ignoring the ones that aren't marked 'isLast'?
+  // Ignore all but the last compeltion result. This means that we get a
+  // precise map of the completion results, rather than a partial list.
   if (event == "completion.results" && params["isLast"]) {
     _onCompletionResults.add(params);
   }

--- a/lib/src/sharded_counter.dart
+++ b/lib/src/sharded_counter.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/**
+ * This library is basic implementation of a sharded counter
+ */
+library services.counter;
+
+import 'dart:math' as math;
+import 'dart:async';
+import 'package:gcloud/db.dart' as db;
+
+final SHARDS_COUNT = 20;
+
+class Counter {
+  static Future increment(String name, {int increment : 1 }) {
+    int shardId = new math.Random().nextInt(SHARDS_COUNT);
+    return _getCounterShard(name, shardId).then((counter) {
+        counter.count++;
+        return db.dbService.withTransaction((transaction) {
+          return transaction.lookup([counter.key]).then((models) {
+            var model = models[0];
+            model.count += increment;
+
+            transaction.queueMutations(inserts: [model]);
+            return transaction.commit();
+          });
+        });
+    });
+  }
+
+  static Future<int> getTotal(String name) {
+    int total = 0;
+    var query = db.dbService.query(_ShardedCounter)
+    ..filter("counterName =", name);
+
+    return query.run().toList().then((models) {
+      models.forEach((m) => total += m.count );
+      return total;
+    });
+  }
+
+  static Future<_ShardedCounter> _getCounterShard(String name, int shardId) {
+    var query = db.dbService.query(_ShardedCounter)
+      ..filter("counterName =", name)
+      ..filter("shardId =", shardId);
+    var results = query.run().toList();
+
+    // Test whether we have been given an id.
+    return results.then((models){
+      if (models.length == 0) {
+        _ShardedCounter newCounter  = new _ShardedCounter()
+           ..counterName = name
+           ..count = 0
+           ..shardId = shardId;
+
+        return db.dbService.commit(inserts: [newCounter]).then((result) {
+             return newCounter;
+           });
+      } else {
+        return new Future.value(models[0]);
+    };
+  });
+  }
+}
+
+@db.Kind()
+class _ShardedCounter extends db.Model {
+
+  @db.StringProperty()
+  String counterName;
+
+  @db.IntProperty()
+  int count;
+
+  @db.IntProperty()
+  int shardId;
+}

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -19,6 +19,7 @@ void defineTests() {
 
   MockCache cache = new MockCache();
   MockRequestRecorder recorder = new MockRequestRecorder();
+  MockCounter counter = new MockCounter();
 
   Future<HttpApiResponse> _sendPostRequest(String path, json) {
     assert(apiServer != null);
@@ -31,7 +32,7 @@ void defineTests() {
     setUp(() {
       if (server == null) {
         String sdkPath = grinder.getSdkDir().path;
-        server = new CommonServer(sdkPath, cache, recorder);
+        server = new CommonServer(sdkPath, cache, recorder, counter);
         apiServer = new ApiServer('/api', prettyPrint: true)..addApi(server);
       }
     });
@@ -148,6 +149,19 @@ class MockRequestRecorder implements SourceRequestRecorder {
 
   @override
   Future record(String verb, String source, [int offset]) {
+    return new Future.value();
+  }
+}
+
+class MockCounter implements PersistentCounter {
+
+  @override
+  Future<int> getTotal(String name) {
+    return new Future.value(42);
+  }
+
+  @override
+  Future increment(String name, {int increment}) {
     return new Future.value();
   }
 }


### PR DESCRIPTION
This PR adds fast sharded counters for total aggregated usage of the various end points:

Currently it's tracking: Number of analyses, Compilations, Completions, Docs, number of lines analyzed and compiled. No PII is recorded only total usage numbers.

It also adds a counters query function to the API.

I'm going to push this to start being able to do in the wild performance testing on 1% of our queries. It also needs a bit more testing to verify that the implementation is properly concurrency safe.

FYI @devoncarew @clayberg