### PR TITLE
Move counter to background writes

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-version: cc-counter
+version: cc-bg-counter
 runtime: custom
 vm: true
 api_version: 1

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -187,8 +187,8 @@ class CommonServer {
         int lineCount = source.split('\n').length;
         int ms = watch.elapsedMilliseconds;
         _logger.info('PERF: Analyzed ${lineCount} lines of Dart in ${ms}ms.');
-        await counter.increment("Analyses");
-        await counter.increment("Analyzed-Lines", increment: lineCount);
+        counter.increment("Analyses");
+        counter.increment("Analyzed-Lines", increment: lineCount);
         return results;
       }).catchError((e) {
         _logger.severe('Error during analyze: ${e}');
@@ -227,8 +227,8 @@ class CommonServer {
             _logger.info(
               'PERF: Compiled ${lineCount} lines of Dart into '
               '${outputSize}kb of JavaScript in ${ms}ms.');
-            await counter.increment("Compilations");
-            await counter.increment("Compiled-Lines", increment: lineCount);
+            counter.increment("Compilations");
+            counter.increment("Compiled-Lines", increment: lineCount);
             String out = results.getOutput();
             return setCache("%%COMPILE:$sourceHash", out).then((_) {
               return new CompileResponse(out);
@@ -262,7 +262,7 @@ class CommonServer {
           if (docInfo == null) docInfo = {};
           _logger.info(
             'PERF: Computed dartdoc in ${watch.elapsedMilliseconds}ms.');
-          await counter.increment("DartDocs");
+          counter.increment("DartDocs");
           return new DocumentResponse(docInfo);
         }).catchError((e, st) {
           _logger.severe('Error during dartdoc: ${e}\n${st}');
@@ -276,7 +276,7 @@ class CommonServer {
 
   Future<CompleteResponse> _complete(String source, int offset) async {
     srcRequestRecorder.record("COMPLETE", source, offset);
-    await counter.increment("Completions");
+    counter.increment("Completions");
     return completer_driver.ensureSetup().then((_) {
       return completer_driver.completeSyncy(source, offset).then((Map response) {
         List<Map> results = response['results'];


### PR DESCRIPTION
FYI @devoncarew The problem with the writes failing was in the use of the dbservices object, it's only available when in the context of a request. So if we want to do background writes, we need to keep this rather than re-querying for it.

Now we do this, we can move to background writes, which buys us a bit less latency - and more important - much lower variability as we're not awaiting a datastore RPC.