### PR TITLE
sends parameter info in a list for use in dartdoc

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -137,6 +137,13 @@ class Analyzer {
         info['description'] = '${element}';
         info['kind'] = element.kind.displayName;
 
+        //parameters for functions and methods
+        if (element is ExecutableElement) {
+          List<String> list = [];
+          element.parameters.forEach((par) => list.add('${par}'));
+          info['parameters'] = list;
+        }
+
         // library
         LibraryElement library = element.library;
 

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -140,7 +140,8 @@ class Analyzer {
         //parameters for functions and methods
         if (element is ExecutableElement) {
           List<String> list = [];
-          element.parameters.forEach((par) => list.add('${par}'));
+          ExecutableElement el = element;
+          el.parameters.forEach((par) => list.add('${par}'));
           info['parameters'] = list;
         }
 


### PR DESCRIPTION
for example, the dartdoc for Stream.listen would have now the extra key

```
  "parameters": [
   "(MouseEvent) → void onData",
   "{Function onError}",
   "{() → void onDone}",
   "{bool cancelOnError}"
  ]
  ```

I think this is useful for example, if you want to show parameter info and you want to do some formatting with that info.