### PR TITLE
Add basic crash protection for completion requests

### DIFF
--- a/lib/src/completer_driver.dart
+++ b/lib/src/completer_driver.dart
@@ -351,7 +351,7 @@ class Server {
    * error response, the future will be completed with an error.
    */
   Future send(String method, Map<String, dynamic> params) {
-    _logger.fine("Server.send $method $params");
+    _logger.fine("Server.send $method");
 
     String id = '${_nextId++}';
     Map<String, dynamic> command = <String, dynamic>{

--- a/lib/src/completer_driver.dart
+++ b/lib/src/completer_driver.dart
@@ -160,7 +160,7 @@ Future<CompletionGetSuggestionsResult> sendCompletionGetSuggestions(
 
 Future<AnalysisUpdateContentResult> sendAddOverlay(
     String file, String contents) {
-  _logger.fine("sendAddOverlay: $file $contents");
+  //_logger.fine("sendAddOverlay: $file $contents");
 
   var overlay = new AddContentOverlay(contents);
   var params = new AnalysisUpdateContentParams({file: overlay}).toJson();

--- a/lib/src/completer_driver.dart
+++ b/lib/src/completer_driver.dart
@@ -20,7 +20,6 @@ io.Directory sourceDirectory = io.Directory.systemTemp.createTempSync('analysisS
 String PACKAGE_ROOT = '/app/packages';
 String SDK = '/usr/lib/dart';
 String SERVER_PATH = "/app/lib/src/analysis_server_server.dart";
-
 bool NEEDS_ENABLE_ASYNC = true;
 
 Server server;
@@ -101,8 +100,14 @@ Future<Map> _complete(String src, int offset) async {
   await analysisComplete.first;
   await sendCompletionGetSuggestions(path, offset);
 
+  // This is using a merged stream of completion results and errors,
+  // stopping on either one of them.
+
   MergeStream completionOrError = new MergeStream();
   completionOrError.add(completionResults);
+
+  // We want to watch on the stream of errors to make sure that the request
+  // returns, even if it's going to fail.
   completionOrError.add(errors);
 
   return completionOrError.stream.first;

--- a/lib/src/completer_driver.dart
+++ b/lib/src/completer_driver.dart
@@ -484,6 +484,11 @@ class Server {
 }
 
 
+///
+/// Class to support merging multiple streams together into one so that
+/// the first item can be extracted from either, this is used for blocking
+/// on either a result or an error.
+///
 class MergeStream {
   final StreamController controller = new StreamController();
 

--- a/lib/src/completer_driver.dart
+++ b/lib/src/completer_driver.dart
@@ -97,7 +97,6 @@ Future setup() async {
 }
 
 Future<Map> _complete(String src, int offset) async {
-
   await sendAddOverlay(path, src);
   await analysisComplete.first;
   await sendCompletionGetSuggestions(path, offset);
@@ -112,10 +111,6 @@ Future<Map> _complete(String src, int offset) async {
 Future<Map> completeSyncy(String src, int offset) async =>
     _complete(src, offset);
 
-//procResults(List results) {
-//  return results.map((r) => r['completion']);
-//}
-
 dispatchNotification(String event, params) async {
   if (event == "server.error") {
     // Something has gone wrong with the analysis server. This request is going
@@ -126,7 +121,7 @@ dispatchNotification(String event, params) async {
 
     await server.kill();
     _onErrors.add(null);
-    _logger.severe("Analysis server has crashed. CRASH CRASH CRASH $event");
+    _logger.severe("Analysis server has crashed. $event");
     return;
   }
 

--- a/lib/src/completer_driver.dart
+++ b/lib/src/completer_driver.dart
@@ -221,7 +221,7 @@ class Server {
   /**
    * True if we are currently printing out messages exchanged with the server.
    */
-  bool _debuggingStdio = true;
+  bool _debuggingStdio = false;
 
   /**
    * True if we've received bad data from the server, and we are aborting the


### PR DESCRIPTION
FYI @devoncarew Hardening work pt1

There's quite a few edits here, but many are rewrites into the much more legible async/wait form.

The basic change here is to introduce a fused stream so that things like completion can wait for 'either completion results or an error' and then fail if it's an error. In local testing this considerable improves hardness to failures of the server.