### PR TITLE
show parent information in dartdoc

### DIFF
--- a/example/apitest.html
+++ b/example/apitest.html
@@ -18,7 +18,7 @@
 
     <h2>Dartpad Server API Tester</h2>
     <input type="text" value="https://dart-services.appspot.com/">
-
+    <!--<input type="text" value="http://localhost:8080/">-->
     <section id="analyzeSection">
       <h3>api/dartservices/v1/analyze</h3>
       <div class="row">

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -133,9 +133,9 @@ class Analyzer {
 
         // Name and description.
         if (element.name != null) info['name'] = element.name;
-        //if (element.displayName != null) info['displayName'] = element.displayName;
         info['description'] = '${element}';
         info['kind'] = element.kind.displayName;
+        info['parent'] = '${element.enclosingElement}';
 
         //parameters for functions and methods
         if (element is ExecutableElement) {

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -135,7 +135,11 @@ class Analyzer {
         if (element.name != null) info['name'] = element.name;
         info['description'] = '${element}';
         info['kind'] = element.kind.displayName;
-        info['parent'] = '${element.enclosingElement}';
+
+        // Only defined if there is an enclosing class.
+        if (element.enclosingElement.kind.name == "CLASS") {
+          info['enclosingClassName'] = '${element.enclosingElement}';
+        }
 
         //parameters for functions and methods
         if (element is ExecutableElement) {

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -156,7 +156,12 @@ class Analyzer {
 
         if (library != null) {
           if (library.name != null && library.name.isNotEmpty) {
-            info['libraryName'] = library.name;
+            // TODO(lukechurch) remove this once this bug is fixed
+            if (library.location.toString() != "utf-8") {
+              info['libraryName'] = '${library.location}';
+            } else {
+              info['libraryName'] = library.name;
+            }
           }
           //info['libraryPath'] = library.source.shortName;
         }

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -137,8 +137,10 @@ class Analyzer {
         info['kind'] = element.kind.displayName;
 
         // Only defined if there is an enclosing class.
-        if (element.enclosingElement.kind.name == "CLASS") {
+        if (element.enclosingElement is ClassElement) {
           info['enclosingClassName'] = '${element.enclosingElement}';
+        } else {
+          info['enclosingClassName'] = null;
         }
 
         //parameters for functions and methods


### PR DESCRIPTION
two examples

```json
{
   "info":{
      "name":"isEven",
      "description":"get isEven → bool",
      "kind":"getter",
      "parent":"int",
      "parameters":[

      ],
      "libraryName":"dart.core",
      "dartdoc":"Returns true if and only if this integer is even.",
      "staticType":"bool"
   }
}
```

```json
{
   "info":{
      "name":"main",
      "description":"main() → void",
      "kind":"function",
      "parent":"main.dart",
      "parameters":[

      ],
      "staticType":"() → void"
   }
}
```