### PR TITLE
extend dartdoc with information about the argument

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -109,6 +109,8 @@ class Analyzer {
 
   Map<String, String> _computeDartdocInfo(CompilationUnit unit, int offset) {
     AstNode node = new NodeLocator.con1(offset).searchWithin(unit);
+    Map info = {};
+    AstNode argument = node;
 
     if (node.parent is TypeName &&
         node.parent.parent is ConstructorName &&
@@ -123,7 +125,6 @@ class Analyzer {
 
     if (node is Expression) {
       Expression expression = node;
-      Map info = {};
 
       // element
       Element element = ElementLocator.locateWithOffset(expression, offset);
@@ -197,11 +198,90 @@ class Analyzer {
       if (expression.propagatedType != null) {
         info['propagatedType'] = '${expression.propagatedType}';
       }
-
+    }
+    Map infoAsArgument = _computeArgumentInfo(argument);
+    if (infoAsArgument != null) {
+      info['infoAsArgument'] = infoAsArgument;
+    }
+    if (info.isEmpty) {
+      return null;
+    } else {
       return info;
     }
+  }
 
-    return null;
+  Map _computeArgumentInfo(AstNode argument) {
+    var method;
+
+    bool emptyArguments = false;
+    while (true) {
+      if (argument.parent == null || argument.parent.parent == null) {
+        argument = null;
+        method = null;
+        break;
+      } else if (argument.parent is ArgumentList) {
+        method = argument.parent.parent;
+        break;
+      } else if (argument is ArgumentList) {
+        emptyArguments = true;
+        method = argument.parent;
+        break;
+      }
+      argument = argument.parent;
+    }
+
+    if (method == null
+        || !(method is MethodInvocation || method is InstanceCreationExpression))
+      return null;
+
+    // method is either InstanceCreationExpression or MethodInvocation
+    // both have the getter argumentList
+    ArgumentList argList = method.argumentList;
+
+    var e = ElementLocator.locateWithOffset(method, method.offset);
+    if (!(e is ExecutableElement)) {
+      return null;
+    }
+    ExecutableElement methodElement = e as ExecutableElement;
+    // list of parameters associated with the method
+    List<ParameterElement> parameters = methodElement.parameters;
+
+    int index;
+    if (emptyArguments) {
+      index = 0;
+    } else if (argument is NamedExpression) {
+      NamedExpression namedArgument = argument as NamedExpression;
+      String name = namedArgument.name.label.toString();
+      //check if we can find the namedArgument in the list of parameters
+      try {
+        var activeParameter = parameters.firstWhere((parameter) => parameter.name == name);
+        index = parameters.indexOf(activeParameter);
+      } on StateError {
+        index = null;
+      }
+      // if we can't find a match, index will be null
+      // which means that the user has misspelled the named parameter
+    } else {
+      // so if it is a positional argument
+      index = argList.arguments.indexOf(argument);
+      if (argList.getPropagatedParameterElementFor(argument) == null
+          && argList.getStaticParameterElementFor(argument) == null) {
+        index = null;
+      }
+    }
+
+    if (index >= parameters.length) {
+      index = null;
+    }
+
+    return  {
+      "name" : emptyArguments ? "" : argument.toString(),
+      "kind" : index == null ? null : parameters[index].parameterKind.toString(),
+      "indexActiveArgument" : index,
+      "parameters" :  parameters.map((param) => '${param}').toList(),
+      "lParenOffset" : argList.leftParenthesis.offset,
+      "rParenOffset" : argList.rightParenthesis.offset,
+    };
   }
 }
 

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -251,26 +251,28 @@ class Analyzer {
       index = 0;
     } else if (argument is NamedExpression) {
       NamedExpression namedArgument = argument;
-      String name = namedArgument.name.label.toString();
+      String nameOfArgument = namedArgument.name.label.toString();
       //check if we can find the namedArgument in the list of parameters
       try {
-        var activeParameter = parameters.firstWhere((parameter) => parameter.name == name);
+        var activeParameter = parameters.firstWhere(
+                (parameter) => parameter.name == nameOfArgument);
         index = parameters.indexOf(activeParameter);
       } on StateError {
         index = null;
       }
       // if we can't find a match, index will be null
       // which means that the user has misspelled the named parameter
-    } else {
+    } else if (argument is Expression){
+      Expression arg = argument;
       // so if it is a positional argument
-      index = argList.arguments.indexOf(argument);
-      if (argList.getPropagatedParameterElementFor(argument) == null
-          && argList.getStaticParameterElementFor(argument) == null) {
+      if (arg.propagatedParameterElement == null && arg.staticParameterElement == null) {
         index = null;
+      } else {
+        index = argList.arguments.indexOf(argument);
       }
     }
 
-    if (index >= parameters.length) {
+    if (index != null && index >= parameters.length) {
       index = null;
     }
 

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -250,7 +250,7 @@ class Analyzer {
     if (emptyArguments) {
       index = 0;
     } else if (argument is NamedExpression) {
-      NamedExpression namedArgument = argument as NamedExpression;
+      NamedExpression namedArgument = argument;
       String name = namedArgument.name.label.toString();
       //check if we can find the namedArgument in the list of parameters
       try {

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -215,7 +215,9 @@ class Analyzer {
 
     bool emptyArguments = false;
     while (true) {
-      if (argument.parent == null || argument.parent.parent == null) {
+      if (argument == argument.parent) {
+        throw 'self-cyclic AST';
+      } else if (argument.parent == null || argument.parent.parent == null) {
         argument = null;
         method = null;
         break;


### PR DESCRIPTION
fix #102 

For example, if you have as input (offset:90):
```dart
import "dart:html";

void main() {
  new HttpRequest().request("url", mimeType:"test");
}
```

You get the following output:
```json
{
   "info":{
      "staticType":"String",
      "infoAsArgument":{
         "name":"mimeType: \"test\"",
         "kind":"NAMED",
         "indexActiveArgument":4,
         "parameters":[
            "String url",
            "{String method}",
            "{bool withCredentials}",
            "{String responseType}",
            "{String mimeType}",
            "{Map<String, String> requestHeaders}",
            "{dynamic sendData}",
            "{(ProgressEvent) → void onProgress}"
         ],
         "lParenOffset":62,
         "rParenOffset":85
      }
   }
}
```