### PR TITLE
plumb through package: support for the compile service call

### DIFF
--- a/doc/generated/v1.dart
+++ b/doc/generated/v1.dart
@@ -3,10 +3,12 @@
 library dartservices_clientlib.dartservices.v1;
 
 import 'dart:core' as core;
+import 'dart:collection' as collection;
 import 'dart:async' as async;
 import 'dart:convert' as convert;
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
+import 'package:crypto/crypto.dart' as crypto;
 import 'package:http/http.dart' as http;
 
 export 'package:_discoveryapis_commons/_discoveryapis_commons.dart' show

--- a/doc/generated/v1.dart
+++ b/doc/generated/v1.dart
@@ -3,12 +3,10 @@
 library dartservices_clientlib.dartservices.v1;
 
 import 'dart:core' as core;
-import 'dart:collection' as collection;
 import 'dart:async' as async;
 import 'dart:convert' as convert;
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
-import 'package:crypto/crypto.dart' as crypto;
 import 'package:http/http.dart' as http;
 
 export 'package:_discoveryapis_commons/_discoveryapis_commons.dart' show

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -18,7 +18,6 @@ import 'package:analyzer/src/generated/parser.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/sdk_io.dart';
 import 'package:analyzer/src/generated/source.dart';
-import 'package:analyzer/src/generated/source_io.dart';
 import 'package:logging/logging.dart';
 
 import 'api_classes.dart';
@@ -27,7 +26,7 @@ import 'common.dart';
 Logger _logger = new Logger('analyzer');
 
 class Analyzer {
-  _StringSource _source;
+  StringSource _source;
   AnalysisContext _context;
 
   Analyzer(String sdkPath) {
@@ -41,7 +40,7 @@ class Analyzer {
     _context.sourceFactory = new SourceFactory(resolvers);
     AnalysisEngine.instance.logger = new _Logger();
 
-    _source = new _StringSource('', 'main.dart');
+    _source = new StringSource('', 'main.dart');
 
     ChangeSet changeSet = new ChangeSet();
     changeSet.addedSource(_source);
@@ -206,13 +205,13 @@ class Analyzer {
 }
 
 /// An implementation of [Source] that is based on an in-memory string.
-class _StringSource implements Source {
+class StringSource implements Source {
   final String fullName;
 
   int _modificationStamp;
   String _contents;
 
-  _StringSource(this._contents, this.fullName)
+  StringSource(this._contents, this.fullName)
       : _modificationStamp = new DateTime.now().millisecondsSinceEpoch;
 
   void updateSource(String newSource) {
@@ -223,8 +222,8 @@ class _StringSource implements Source {
   int get modificationStamp => _modificationStamp;
 
   bool operator==(Object object) {
-    if (object is _StringSource) {
-      _StringSource ssObject = object;
+    if (object is StringSource) {
+      StringSource ssObject = object;
       return ssObject._contents == _contents && ssObject.fullName == fullName;
     }
     return false;

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -178,7 +178,9 @@ class CommonServer {
 
     // TODO(lukechurch): Remove this hack after
     // https://github.com/dart-lang/rpc/issues/15 lands
-    bool suppressCache = source.trim().endsWith("/** Suppress-Memcache **/");
+    var trimSrc = source.trim();
+    bool suppressCache = trimSrc.endsWith("/** Supress-Memcache **/") ||
+        trimSrc.endsWith("/** Suppress-Memcache **/");
 
     return checkCache("%%COMPILE:$sourceHash").then((String result) {
       if (!suppressCache && result != null) {

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -14,9 +14,13 @@ import 'api_classes.dart';
 import 'analysis_server.dart';
 import 'analyzer.dart';
 import 'compiler.dart';
+import 'pub.dart';
 
 final Duration _standardExpiration = new Duration(hours: 1);
 final Logger _logger = new Logger('common_server');
+
+/// Toggle to on to enable `package:` support.
+final bool enablePackages = false;
 
 abstract class ServerCache {
   Future<String> get(String key);
@@ -43,6 +47,7 @@ class CommonServer {
   final SourceRequestRecorder srcRequestRecorder;
   final PersistentCounter counter;
 
+  Pub pub;
   Analyzer analyzer;
   Compiler compiler;
   AnalysisServerWrapper analysisServer;
@@ -53,8 +58,11 @@ class CommonServer {
       this.counter) {
     hierarchicalLoggingEnabled = true;
     _logger.level = Level.ALL;
+
+    pub = enablePackages ? new Pub() : new Pub.mock();
+
     analyzer = new Analyzer(sdkPath);
-    compiler = new Compiler(sdkPath);
+    compiler = new Compiler(sdkPath, pub);
     analysisServer = new AnalysisServerWrapper(sdkPath);
   }
 
@@ -170,14 +178,14 @@ class CommonServer {
 
     // TODO(lukechurch): Remove this hack after
     // https://github.com/dart-lang/rpc/issues/15 lands
-    bool supressCache = source.trim().endsWith("/** Supress-Memcache **/");
+    bool suppressCache = source.trim().endsWith("/** Suppress-Memcache **/");
 
     return checkCache("%%COMPILE:$sourceHash").then((String result) {
-      if (!supressCache && result != null) {
+      if (!suppressCache && result != null) {
         _logger.info("CACHE: Cache hit for compile");
         return new CompileResponse(result);
       } else {
-        _logger.info("CACHE: MISS, forced: $supressCache");
+        _logger.info("CACHE: MISS, forced: $suppressCache");
         Stopwatch watch = new Stopwatch()..start();
 
         return compiler.compile(source).then((CompilationResults results) async {

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -192,7 +192,7 @@ class _CompilerProvider {
         return new Future.value(contents);
       }
     } else if (uri.scheme == 'package' && pubHelper != null) {
-      return pubHelper.getPackageContentsAsync(uri.path.substring(1));
+      return pubHelper.getPackageContentsAsync('package:${uri.path.substring(1)}');
     }
 
     return new Future.error('file not found');

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -36,29 +36,28 @@ class Compiler {
       compile(useHtml ? sampleCodeWeb : sampleCode);
 
   /// Compile the given string and return the resulting [CompilationResults].
-  Future<CompilationResults> compile(String input) {
-    Future<PubHelper> f = pub == null ?
-        new Future.value() : pub.createPubHelperForSource(input);
+  Future<CompilationResults> compile(String input) async {
+    PubHelper pubHelper = null;
 
-    return f.then((pubHelper) {
-      _CompilerProvider provider = new _CompilerProvider(_sdk, input, pubHelper);
+    if (pub != null) {
+      pubHelper = await pub.createPubHelperForSource(input);
+    }
 
-      Lines lines = new Lines(input);
+    _CompilerProvider provider = new _CompilerProvider(_sdk, input, pubHelper);
+    Lines lines = new Lines(input);
+    CompilationResults result = new CompilationResults(lines);
 
-      CompilationResults result = new CompilationResults(lines);
-
-      // --incremental-support, --disable-type-inference
-      return compiler.compile(
-          provider.getInitialUri(),
-          new Uri(scheme: 'sdk', path: '/'),
-          new Uri(scheme: 'package', path: '/'),
-          provider.inputProvider,
-          result._diagnosticHandler,
-          ['--no-source-maps'],
-          result._outputProvider).then((_) {
-        result._problems.sort();
-        return result;
-      });
+    // --incremental-support, --disable-type-inference
+    return compiler.compile(
+        provider.getInitialUri(),
+        new Uri(scheme: 'sdk', path: '/'),
+        new Uri(scheme: 'package', path: '/'),
+        provider.inputProvider,
+        result._diagnosticHandler,
+        ['--no-source-maps'],
+        result._outputProvider).then((_) {
+      result._problems.sort();
+      return result;
     });
   }
 }

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -37,7 +37,9 @@ class Compiler {
 
   /// Compile the given string and return the resulting [CompilationResults].
   Future<CompilationResults> compile(String input) {
-    Future<PubHelper> f = pub == null ? null : pub.createPubHelperForSource(input);
+    Future<PubHelper> f = pub == null ?
+        new Future.value() : pub.createPubHelperForSource(input);
+
     return f.then((pubHelper) {
       _CompilerProvider provider = new _CompilerProvider(_sdk, input, pubHelper);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   crypto: '>=0.9.0 <0.10.0'
   librato: '>=0.0.1 <0.1.0'
   logging: ^0.9.0
+  path: ^1.3.0
   shelf: ^0.5.0
   shelf_cors: ^0.2.0
   shelf_route: ^0.11.0


### PR DESCRIPTION
@lukechurch, additional work towards `package:` support:

- added a `enablePackages` compile time flag; currently off
- added a method to scan source code and extract package: imports
- added tests for the above
- added a helper class to parse source for imports, and provide methods to locate package resources
- plumbed all this through the `compile/` service call. analyzer and AS related calls not yet supported -