### PR TITLE
improve JS compile errors

### DIFF
--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -205,10 +205,8 @@ class CommonServer {
               return new CompileResponse(out);
             });
           } else {
-            String errors =
-              results.problems.map(_printCompileProblem).join('\n');
-            throw new BadRequestError(
-              'Compilation of $sourceHash failed with errors: $errors');
+            String errors = results.problems.map(_printCompileProblem).join('\n');
+            throw new BadRequestError(errors);
           }
         }).catchError((e, st) {
           _logger.severe('Error during compile: ${e}\n${st}');

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -7,9 +7,9 @@ library services.common_server_test;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:services/src/common.dart';
 import 'package:services/src/common_server.dart';
-import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:rpc/rpc.dart';
 import 'package:unittest/unittest.dart';
 
@@ -87,8 +87,7 @@ void defineTests() {
       expect(response.status, 400);
       var data = JSON.decode(UTF8.decode(await response.body.first));
       expect(data, isNotEmpty);
-      expect(data['error']['message'],
-          contains('failed with errors: [error, line 2] Expected'));
+      expect(data['error']['message'], contains('[error, line 2] Expected'));
     });
 
     test('compile negative-test noSource', () async {

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -23,7 +23,7 @@ void defineTests() {
       return pub.resolvePackages(['test']).then((PackagesInfo result) {
         expect(result, isNotNull);
         expect(result.packages, isNotEmpty);
-        expect(result.packages.length, 1);
+        expect(result.packages.length, greaterThanOrEqualTo(1));
         expect(result.packages[0].name, 'test');
       });
     });


### PR DESCRIPTION
Address https://github.com/dart-lang/dart-pad/issues/3. Change:
```
Error compiling to JavaScript:
Compilation of e9a619af3df7cb03f9a8556ede5968ce2892b768 failed with errors:
[error, line 1] Library not found 'dart:io'.
```

to

```
Error compiling to JavaScript:
[error, line 1] Library not found 'dart:io'.
```

@lukechurch 