### PR TITLE
Support format API

### DIFF
--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -78,9 +78,12 @@ class AnalysisServerWrapper {
     var results = _formatImpl(src, offset);
     return results.then((editResult) {
       String editSrc = src;
-      editResult.edits.forEach((edit) {
+      List<SourceEdit> edits = editResult.edits;
+      edits.sort((e1, e2) => -1 * e1.offset.compareTo(e2.offset));
+
+      for (var edit in edits) {
         editSrc = edit.apply(editSrc);
-      });
+      }
       return new api.FormatResponse(editSrc);
     });
   }

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -14,7 +14,7 @@ import 'package:analysis_server/src/protocol.dart';
 import 'package:logging/logging.dart';
 import 'analyzer.dart';
 
-import 'api_classes.dart';
+import 'api_classes.dart' as api;
 
 /**
  * Type of callbacks used to process notifications.
@@ -36,6 +36,9 @@ final _SERVER_PATH = "bin/_analysis_server_entry.dart";
 class AnalysisServerWrapper {
   final String sdkPath;
 
+  // Needed to do fast verification check before formatting.
+  // TODO(lukechurch): Replace this with listening to server errors and
+  // warnings.
   Analyzer analyzer;
 
   /// Instance to handle communication with the server.
@@ -46,7 +49,7 @@ class AnalysisServerWrapper {
     analyzer = new Analyzer(this.sdkPath);
   }
 
-  Future<CompleteResponse> complete(String src, int offset) async {
+  Future<api.CompleteResponse> complete(String src, int offset) async {
     Future<Map> results = _completeImpl(src, offset);
 
     // Post process the result from Analysis Server.
@@ -66,23 +69,23 @@ class AnalysisServerWrapper {
         } else {
           return -1 * xRelevance.compareTo(yRelevance);
         }});
-      return new CompleteResponse(
+      return new api.CompleteResponse(
           response['replacementOffset'], response['replacementLength'],
           results);
     });
   }
 
-  Future<FixesResponse> getFixes(String src, int offset) async {
+  Future<api.FixesResponse> getFixes(String src, int offset) async {
     var results = _getFixesImpl(src, offset);
     return results.then((fixes) {
-      return new FixesResponse(fixes.fixes);
+      return new api.FixesResponse(fixes.fixes);
     });
   }
 
-  Future<FormatResponse> format(String src) async {
+  Future<api.FormatResponse> format(String src) async {
     var results = _formatImpl(src);
     return results.then((editResult) {
-      return new FormatResponse(editResult);
+      return new api.FormatResponse(editResult);
     });
   }
 
@@ -114,7 +117,7 @@ class AnalysisServerWrapper {
 
   Future<EditFormatResult> _formatImpl(String src) async {
 
-    AnalysisResults analysisResults = await analyzer.analyze(src);
+    api.AnalysisResults analysisResults = await analyzer.analyze(src);
     if (analysisResults.issues.where(
             (issue) => issue.kind == "error").length > 0)
       return new Future.value(new EditFormatResult(

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -79,7 +79,7 @@ class AnalysisServerWrapper {
     return results.then((editResult) {
       String editSrc = src;
       editResult.edits.forEach((edit) {
-        editSrc = edit.apply(s);
+        editSrc = edit.apply(editSrc);
       });
       return new api.FormatResponse(editSrc);
     });

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -127,9 +127,9 @@ class AnalysisServerWrapper {
 
     await serverConnection.sendAddOverlay(src);
     await serverConnection.analysisComplete.first;
-    var fixes = await serverConnection.sendFormat();
+    var formatResult = await serverConnection.sendFormat();
     serverConnection.sendRemoveOverlay();
-    return fixes;
+    return formatResult;
   }
 
 
@@ -199,15 +199,15 @@ class _Server {
     _logger.fine("Setver started");
 
     listenToOutput(dispatchNotification);
-    await sendServerSetSubscriptions([ServerService.STATUS]);
+    sendServerSetSubscriptions([ServerService.STATUS]);
 
     _logger.fine("Server Set Subscriptions completed");
 
     psudeoFile.writeAsStringSync("", flush: true);
 
     await sendAddOverlay(_WARMUP_SRC);
-    await sendAnalysisSetAnalysisRoots([sourceDirectory.path], []);
-    await sendPrioritySetSources([psuedoFilePath]);
+    sendAnalysisSetAnalysisRoots([sourceDirectory.path], []);
+    sendPrioritySetSources([psuedoFilePath]);
     isSettingUp = false;
     isSetup = true;
 

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -186,6 +186,23 @@ class CandidateFix {
   CandidateFix(this.message, this.edits);
 }
 
+/*
+ * Represents a reformatting of the code.
+ */
+class FormatResponse {
+  List<SourceEdit> edits;
+
+  FormatResponse(EditFormatResult format) {
+    edits = [];
+
+    format.edits.forEach((edit) => edits.add(
+      new SourceEdit(edit.offset,
+        edit.length != null ? edit.length : 0,
+        edit.replacement != null ? edit.replacement : 0)
+    ));
+  }
+}
+
 /**
  * Represents a single edit-point change to a source file.
  */
@@ -195,4 +212,5 @@ class SourceEdit {
   final String replacement;
 
   SourceEdit(this.offset, this.length, this.replacement);
+
 }

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -190,17 +190,10 @@ class CandidateFix {
  * Represents a reformatting of the code.
  */
 class FormatResponse {
-  List<SourceEdit> edits;
+  String newString;
+  int offset;
 
-  FormatResponse(EditFormatResult format) {
-    edits = [];
-
-    format.edits.forEach((edit) => edits.add(
-      new SourceEdit(edit.offset,
-        edit.length != null ? edit.length : 0,
-        edit.replacement != null ? edit.replacement : 0)
-    ));
-  }
+  FormatResponse(this.newString, [this.offset = 0]);
 }
 
 /**
@@ -213,4 +206,15 @@ class SourceEdit {
 
   SourceEdit(this.offset, this.length, this.replacement);
 
+  String applyTo(String target) {
+    if (offset >= replacement.length) {
+      throw "Offset beyond end of string";
+    } else if (offset + length >= replacement.length) {
+      throw "Change beyond end of string";
+    }
+
+    String pre = "${target.substring(0, offset)}";
+    String post = "${target.substring(offset+length)}";
+    return "$pre$replacement$post";
+  }
 }

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -190,8 +190,8 @@ class CandidateFix {
  * Represents a reformatting of the code.
  */
 class FormatResponse {
-  String newString;
-  int offset;
+  final String newString;
+  final int offset;
 
   FormatResponse(this.newString, [this.offset = 0]);
 }

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -128,12 +128,12 @@ class CommonServer {
   }
 
   @ApiMethod(method: 'POST', path: 'format')
-  Future<FixesResponse> format(SourceRequest request) {
+  Future<FormatResponse> format(SourceRequest request) {
     return _format(request.source);
   }
 
-  @ApiMethod(method: 'POST', path: 'format')
-  Future<FixesResponse> formatGet({String source}) {
+  @ApiMethod(method: 'GET', path: 'format')
+  Future<FormatResponse> formatGet({String source}) {
     if (source == null) {
       throw new BadRequestError('Missing parameter: \'source\'');
     }

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -127,6 +127,20 @@ class CommonServer {
     return _fix(source, offset);
   }
 
+  @ApiMethod(method: 'POST', path: 'format')
+  Future<FixesResponse> format(SourceRequest request) {
+    return _format(request.source);
+  }
+
+  @ApiMethod(method: 'POST', path: 'format')
+  Future<FixesResponse> formatGet({String source}) {
+    if (source == null) {
+      throw new BadRequestError('Missing parameter: \'source\'');
+    }
+    return _format(source);
+  }
+
+
   @ApiMethod(method: 'POST', path: 'document')
   Future<DocumentResponse> document(SourceRequest request) {
     return _document(request.source, request.offset);
@@ -246,6 +260,12 @@ class CommonServer {
       counter.increment("Fixes");
       return analysisServer.getFixes(source, offset);
     }
+
+  Future<FormatResponse> _format(String source) async {
+    srcRequestRecorder.record("FORMAT", source);
+    counter.increment("Formats");
+    return analysisServer.format(source);
+  }
 
   Future<String> checkCache(String query) => cache.get(query);
 

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -32,6 +32,21 @@ void main() {
 }
 ''';
 
+String badFormatCode =
+r'''
+void main()
+{
+int i = 0;
+}
+''';
+
+String formattedCode =
+r'''
+void main() {
+  int i = 0;
+}
+''';
+
 void defineTests() {
   AnalysisServerWrapper analysisServer;
 
@@ -88,6 +103,15 @@ void defineTests() {
         expect(fix.edits[0].replacement, ";");
       });
     });
+
+//    test('simple_format', () {
+//      //Just after i.
+//      return analysisServer.format(badFormatCode).then(
+//        (FormatResponse results) {
+//          expect(results.edits.length, 1);
+//          expect(results.edits[0].replacement, formattedCode);
+//        });
+//    });
   });
 }
 

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -104,6 +104,7 @@ void defineTests() {
       });
     });
 
+// TODO(lukechurch): Enable once https://code.google.com/p/dart/issues/detail?id=23230 lands
 //    test('simple_format', () {
 //      //Just after i.
 //      return analysisServer.format(badFormatCode).then(

--- a/tool/slow_test.dart
+++ b/tool/slow_test.dart
@@ -145,7 +145,7 @@ testFixes(String src, analysis_server.AnalysisServerWrapper wrapper) async {
 
 testFormat(String src, analysis_server.AnalysisServerWrapper wrapper) async {
   Stopwatch sw = new Stopwatch()..start();
-  await wrapper.format(src);
+  await wrapper.format(src, 0);
   return sw.elapsedMilliseconds;
 }
 

--- a/tool/slow_test.dart
+++ b/tool/slow_test.dart
@@ -51,6 +51,7 @@ main (List<String> args) async {
       r = new Random(seed);
       seed++;
       await testPath(fse.path, analysisServer, analyzer, compiler);
+
     } catch (e) {
       print (e);
       print ("FAILED: ${fse.path}");
@@ -78,26 +79,32 @@ testPath(String path,
   f = null;
 
   for (int i = 0; i < 5; i++) {
-    int noChanges = r.nextInt(20);
 
-    for (int j = 0; j < noChanges; j++) {
-      src = mutate(src);
-    }
-
+    // Run once for each file without mutation.
     var averageCompletionTime = await testCompletions(src, wrapper);
     var averageAnalysisTime = await testAnalysis(src, analyzer);
     var averageDocumentTime = await testDocument(src, analyzer);
     var averageCompilationTime = await testCompilation(src, compiler);
     var averageFixesTime = await testFixes(src, wrapper);
+    var averageFormatTime = await testFormat(src, wrapper);
+
 
     print (
-      "$path-$i - $noChanges, "
+      "$path-$i, "
       "${averageCompilationTime.toStringAsFixed(2)}ms, "
       "${averageAnalysisTime.toStringAsFixed(2)}ms, "
       "${averageCompletionTime.toStringAsFixed(2)}ms, "
       "${averageDocumentTime.toStringAsFixed(2)}ms, "
-      "${averageFixesTime.toStringAsFixed(2)}ms"
+      "${averageFixesTime.toStringAsFixed(2)}ms, "
+      "${averageFormatTime.toStringAsFixed(2)}ms"
       );
+
+    // And then for the remainder with an increasing mutated file.
+    int noChanges = r.nextInt(20);
+
+    for (int j = 0; j < noChanges; j++) {
+      src = mutate(src);
+    }
   }
 }
 
@@ -136,6 +143,13 @@ testFixes(String src, analysis_server.AnalysisServerWrapper wrapper) async {
   }
   return sw.elapsedMilliseconds / src.length;
 }
+
+testFormat(String src, analysis_server.AnalysisServerWrapper wrapper) async {
+  Stopwatch sw = new Stopwatch()..start();
+  await wrapper.format(src);
+  return sw.elapsedMilliseconds;
+}
+
 
 mutate(String src) {
   var c = ["{", "}", "[", "]", "'", ",", "!", "@", "#", "\$", "%",


### PR DESCRIPTION
This enables support for formatting.

It's not ready to be deployed until a solution to https://code.google.com/p/dart/issues/detail?id=23230 is agreed.

This is more to give @kasperpeulen a sense of what the API is going to be like. Note it formats the whole file at once. The region selection in the Server API doesn't actually allow selective formatting, it just allows the selection to be persisted between formats.

Note that guarding the API with an analysis call is needed due to the way the format API currently works.