### PR TITLE
upgrade dart2js to 1.9.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   args: ^0.12.0
   cli_util: ^0.0.1
   # `compiler_unsupported` needs to be pegged to a specific version.
-  compiler_unsupported: 1.9.0-dev.10.4
+  compiler_unsupported: 1.9.3
   crypto: '>=0.9.0 <0.10.0'
   librato: '>=0.0.1 <0.1.0'
   logging: ^0.9.0

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -20,11 +20,11 @@ void defineTests() {
     });
 
     test('resolvePackages simple', () {
-      return pub.resolvePackages(['test']).then((PackagesInfo result) {
+      return pub.resolvePackages(['path']).then((PackagesInfo result) {
         expect(result, isNotNull);
         expect(result.packages, isNotEmpty);
         expect(result.packages.length, greaterThanOrEqualTo(1));
-        expect(result.packages[0].name, 'test');
+        expect(result.packages.map((p) => p.name), contains('path'));
       });
     });
 


### PR DESCRIPTION
- fix #138 
- also, make a pub test more robust

@lukechurch 