### PR TITLE
improve compiler error messages

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -134,10 +134,16 @@ class CompilationProblem implements Comparable {
     return INFO;
   }
 
+  bool get isHint => _diagnostic == compiler.Diagnostic.HINT;
+
   int compareTo(CompilationProblem other) {
     return severity == other.severity
         ? line - other.line : other.severity - severity;
   }
+
+  bool get isOnCompileTarget => uri != null && uri.scheme == 'resource';
+
+  bool get isOnSdk => uri != null && uri.scheme == 'sdk';
 
   String toString() {
     if (uri == null) {

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -87,7 +87,7 @@ void defineTests() {
       expect(response.status, 400);
       var data = JSON.decode(UTF8.decode(await response.body.first));
       expect(data, isNotEmpty);
-      expect(data['error']['message'], contains('[error, line 2] Expected'));
+      expect(data['error']['message'], contains('[error on line 2] Expected'));
     });
 
     test('compile negative-test noSource', () async {


### PR DESCRIPTION
Improve compiler error messages

- try and filter out dart2js hints, as well as errors/warnings on files that are not the user's source
- when printing locations for errors, only include line numbers for the user's source (line numbers in sdk errors don't help the user)

@lukechurch 