### PR TITLE
Re-enable analysis-server based common server tests

### DIFF
--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -39,6 +39,7 @@ class AnalysisServerWrapper {
   _Server serverConnection;
 
   AnalysisServerWrapper(this.sdkPath) {
+    _logger.info("AnalysisServerWrapper ctor");
     serverConnection = new _Server(this.sdkPath);
   }
 

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -66,6 +66,14 @@ class CommonServer {
     analysisServer = new AnalysisServerWrapper(sdkPath);
   }
 
+  Future warmup([bool useHtml = false]) async {
+    await analyzer.warmup(useHtml);
+    await compiler.warmup(useHtml);
+    await analysisServer.warmup(useHtml);
+  }
+
+  Future shutdown() => analysisServer.shutdown();
+
   @ApiMethod(method: 'GET', path: 'counter')
   Future<CounterResponse> counterGet({String name}) {
     return counter.getTotal(name).then((total) {

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -54,9 +54,7 @@ void defineTests() {
       analysisServer = new AnalysisServerWrapper(sdkPath);
     });
 
-    tearDown(() {
-      analysisServer.shutdown();
-    });
+    tearDown(() => analysisServer.shutdown());
 
     test('simple_completion', () {
       //Just after i.

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -30,12 +30,13 @@ void defineTests() {
 
   group('CommonServer', () {
     setUp(() {
-      if (server == null) {
-        String sdkPath = cli_util.getSdkDir([]).path;
-        server = new CommonServer(sdkPath, cache, recorder, counter);
-        apiServer = new ApiServer('/api', prettyPrint: true)..addApi(server);
-      }
+      String sdkPath = cli_util.getSdkDir([]).path;
+      server = new CommonServer(sdkPath, cache, recorder, counter);
+      apiServer = new ApiServer('/api', prettyPrint: true)..addApi(server);
+      return server.warmup();
     });
+
+    tearDown(() => server.shutdown());
 
     test('analyze', () async {
       var json = {'source': sampleCode};
@@ -96,7 +97,6 @@ void defineTests() {
         expect(response.status, 400);
      });
 
-    /*
     test('complete', () async {
       var json = {'source': 'void main() {print("foo");}', 'offset': 1};
       var response = await _sendPostRequest('dartservices/v1/complete', json);
@@ -123,7 +123,6 @@ void defineTests() {
       var data = JSON.decode(UTF8.decode(await response.body.first));
       expect(data['error']['message'], 'Missing parameter: \'offset\'');
     });
-     */
 
     test('document', () async {
       var json = {'source': 'void main() {print("foo");}', 'offset': 17};
@@ -149,20 +148,18 @@ void defineTests() {
       expect(data, {"info": {}});
     });
 
-  });
-
-  test('document negative-test noSource', () async {
+    test('document negative-test noSource', () async {
       var json = { 'offset': 12 };
       var response = await _sendPostRequest('dartservices/v1/document', json);
       expect(response.status, 400);
-   });
+    });
 
-  test('document negative-test noOffset', () async {
+    test('document negative-test noOffset', () async {
       var json = {'source': 'void main() {print("foo");}' };
       var response = await _sendPostRequest('dartservices/v1/document', json);
       expect(response.status, 400);
-   });
-
+    });
+  });
 }
 
 class MockCache implements ServerCache {


### PR DESCRIPTION
These have been disabled over a problem shutting down Analysis Server.

This fixes the shutdown problem, moves a couple of the tests into a group, and renables the previous commented out tests.

TBR @devoncarew 