### PR TITLE
Upgrade RPC library

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -20,7 +20,7 @@ class DartservicesApi {
 
   final commons.ApiRequester _requester;
 
-  DartservicesApi(http.Client client, {core.String rootUrl: "http://localhost/", core.String servicePath: "api/dartservices/v1/"}) :
+  DartservicesApi(http.Client client, {core.String rootUrl: "/", core.String servicePath: "api/dartservices/v1/"}) :
       _requester = new commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
 
   /**

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,15 +1,15 @@
 {
  "kind": "discovery#restDescription",
- "etag": "326704774ef7358f4cc3c237ee8c6bdc4d9d0b80",
+ "etag": "bd4e8cff8c987967ead41a32e025116cb6637f6f",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
  "version": "v1",
  "revision": "0",
  "protocol": "rest",
- "baseUrl": "http://localhost/api/dartservices/v1/",
+ "baseUrl": "/api/dartservices/v1/",
  "basePath": "/api/dartservices/v1/",
- "rootUrl": "http://localhost/",
+ "rootUrl": "/",
  "servicePath": "api/dartservices/v1/",
  "parameters": {},
  "schemas": {

--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -57,7 +57,7 @@ class GaeServer {
         new GaeCounter());
     // Enabled pretty printing of returned json for debuggability.
     apiServer =
-        new rpc.ApiServer(_API, prettyPrint: true)..addApi(commonServer);
+        new rpc.ApiServer(apiPrefix: _API, prettyPrint: true)..addApi(commonServer);
   }
 
   Future start() => ae.runAppEngine(requestHandler);
@@ -87,13 +87,13 @@ class GaeServer {
 
     if (request.uri.path.startsWith(_API)) {
       if (!discoveryEnabled) {
-        apiServer.enableDiscoveryApi(request.requestedUri.origin);
+        apiServer.enableDiscoveryApi();
         discoveryEnabled = true;
       }
       // NOTE: We could read in the request body here and parse it similar to
       // the _parseRequest method to determine content-type and dispatch to e.g.
       // a plain text handler if we want to support that.
-      var apiRequest = new rpc.HttpApiRequest.fromHttpRequest(request, _API);
+      var apiRequest = new rpc.HttpApiRequest.fromHttpRequest(request);
       apiServer.handleHttpApiRequest(apiRequest)
         .then((rpc.HttpApiResponse apiResponse) {
           return rpc.sendApiResponse(apiResponse, request.response);

--- a/lib/services_server.dart
+++ b/lib/services_server.dart
@@ -81,12 +81,15 @@ class EndpointsServer {
         new _Recorder(),
         new _Counter());
     var apiServer =
-        new ApiServer('/api', prettyPrint: true)..addApi(commonServer);
-    apiServer.enableDiscoveryApi(serverUrl);
+        new ApiServer(apiPrefix: '/api', prettyPrint: true)..addApi(commonServer);
+    apiServer.enableDiscoveryApi();
+
+    var uri = Uri.parse("http://localhost/discovery/v1/apis/dartservices/v1/rest");
+
     var request =
         new HttpApiRequest('GET',
-                           'discovery/v1/apis/dartservices/v1/rest',
-                           {}, {}, new Stream.fromIterable([]));
+                           uri,
+                           {}, new Stream.fromIterable([]));
     HttpApiResponse response = await apiServer.handleHttpApiRequest(request);
     return UTF8.decode(await response.body.first);
   }
@@ -109,7 +112,7 @@ class EndpointsServer {
         new _Cache(),
         new _Recorder(),
         new _Counter());
-    apiServer = new ApiServer('/api', prettyPrint: true)..addApi(commonServer);
+    apiServer = new ApiServer(apiPrefix: '/api', prettyPrint: true)..addApi(commonServer);
 
     pipeline = new Pipeline()
       .addMiddleware(logRequests())
@@ -124,14 +127,13 @@ class EndpointsServer {
 
   Future<Response> _apiHandler(Request request) {
     if (!discoveryEnabled) {
-      apiServer.enableDiscoveryApi(request.requestedUri.origin);
+      apiServer.enableDiscoveryApi();
       discoveryEnabled = true;
     }
     // NOTE: We could read in the request body here and parse it similar to
     // the _parseRequest method to determine content-type and dispatch to e.g.
     // a plain text handler if we want to support that.
-    var apiRequest = new HttpApiRequest(request.method, request.url.path,
-                                        request.url.queryParameters,
+    var apiRequest = new HttpApiRequest(request.method, request.url,
                                         request.headers,
                                         request.read());
     return apiServer.handleHttpApiRequest(apiRequest)

--- a/lib/services_server.dart
+++ b/lib/services_server.dart
@@ -84,7 +84,7 @@ class EndpointsServer {
         new ApiServer(apiPrefix: '/api', prettyPrint: true)..addApi(commonServer);
     apiServer.enableDiscoveryApi();
 
-    var uri = Uri.parse("http://localhost/discovery/v1/apis/dartservices/v1/rest");
+    var uri = Uri.parse("/api/discovery/v1/apis/dartservices/v1/rest");
 
     var request =
         new HttpApiRequest('GET',

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -62,7 +62,7 @@ class AnalysisServerWrapper {
         } else {
           return -1 * xRelevance.compareTo(yRelevance);
         }});
-      return new api.CompleteResponse(
+      return new api.CompleteResponse.byCompletions(
           response['replacementOffset'], response['replacementLength'],
           results);
     });
@@ -71,7 +71,7 @@ class AnalysisServerWrapper {
   Future<api.FixesResponse> getFixes(String src, int offset) async {
     var results = _getFixesImpl(src, offset);
     return results.then((fixes) {
-      return new api.FixesResponse(fixes.fixes);
+      return new api.FixesResponse.byFixes(fixes.fixes);
     });
   }
 
@@ -85,7 +85,7 @@ class AnalysisServerWrapper {
       for (var edit in edits) {
         editSrc = edit.apply(editSrc);
       }
-      return new api.FormatResponse(editSrc, editResult.selectionOffset);
+      return new api.FormatResponse.byCode(editSrc, editResult.selectionOffset);
     });
   }
 

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -62,7 +62,7 @@ class AnalysisServerWrapper {
         } else {
           return -1 * xRelevance.compareTo(yRelevance);
         }});
-      return new api.CompleteResponse.byCompletions(
+      return new api.CompleteResponse.fromCompletions(
           response['replacementOffset'], response['replacementLength'],
           results);
     });
@@ -71,7 +71,7 @@ class AnalysisServerWrapper {
   Future<api.FixesResponse> getFixes(String src, int offset) async {
     var results = _getFixesImpl(src, offset);
     return results.then((fixes) {
-      return new api.FixesResponse.byFixes(fixes.fixes);
+      return new api.FixesResponse.fromFixes(fixes.fixes);
     });
   }
 
@@ -85,7 +85,7 @@ class AnalysisServerWrapper {
       for (var edit in edits) {
         editSrc = edit.apply(editSrc);
       }
-      return new api.FormatResponse.byCode(editSrc, editResult.selectionOffset);
+      return new api.FormatResponse.fromCode(editSrc, editResult.selectionOffset);
     });
   }
 

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -79,7 +79,7 @@ class Analyzer {
         .toList();
 
       List<AnalysisIssue> issues = errors.map((_Error error) {
-        return new AnalysisIssue.byIssue(
+        return new AnalysisIssue.fromIssue(
             error.severityName, error.line, error.message,
             location: error.location,
             charStart: error.offset, charLength: error.length,
@@ -88,7 +88,7 @@ class Analyzer {
 
       issues.sort();
 
-      return new Future.value(new AnalysisResults.byIssues(issues));
+      return new Future.value(new AnalysisResults.fromIssues(issues));
     } catch (e, st) {
       return new Future.error(e, st);
     }

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -79,7 +79,7 @@ class Analyzer {
         .toList();
 
       List<AnalysisIssue> issues = errors.map((_Error error) {
-        return new AnalysisIssue(
+        return new AnalysisIssue.byIssue(
             error.severityName, error.line, error.message,
             location: error.location,
             charStart: error.offset, charLength: error.length,
@@ -88,7 +88,7 @@ class Analyzer {
 
       issues.sort();
 
-      return new Future.value(new AnalysisResults(issues));
+      return new Future.value(new AnalysisResults.byIssues(issues));
     } catch (e, st) {
       return new Future.error(e, st);
     }

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -13,8 +13,8 @@ import 'package:rpc/rpc.dart';
 class AnalysisResults {
   final List<AnalysisIssue> issues;
 
-  AnalysisResults() : this.byIssues([]);
-  AnalysisResults.byIssues(this.issues);
+  AnalysisResults() : this.fromIssues([]);
+  AnalysisResults.fromIssues(this.issues);
 }
 
 class AnalysisIssue implements Comparable {
@@ -28,8 +28,8 @@ class AnalysisIssue implements Comparable {
   final int charLength;
   final String location;
 
-  AnalysisIssue() : this.byIssue("", 0, "");
-  AnalysisIssue.byIssue(this.kind, this.line, this.message,
+  AnalysisIssue() : this.fromIssue("", 0, "");
+  AnalysisIssue.fromIssue(this.kind, this.line, this.message,
       {this.charStart, this.charLength, this.location, this.hasFixes: false});
 
   Map toMap() {
@@ -58,8 +58,8 @@ class SourceRequest {
 class CompileResponse {
   final String result;
 
-  CompileResponse() : this.byResponse("");
-  CompileResponse.byResponse(this.result);
+  CompileResponse() : this.fromResponse("");
+  CompileResponse.fromResponse(this.result);
 }
 
 class CounterRequest {
@@ -70,15 +70,15 @@ class CounterRequest {
 class CounterResponse {
   final int count;
 
-  CounterResponse() : this.byCount(0);
-  CounterResponse.byCount(this.count);
+  CounterResponse() : this.fromCount(0);
+  CounterResponse.fromCount(this.count);
 }
 
 class DocumentResponse {
   final Map<String, String> info;
 
-  DocumentResponse() : this.byInfo();
-  DocumentResponse.byInfo([this.info]);
+  DocumentResponse() : this.fromInfo();
+  DocumentResponse.fromInfo([this.info]);
 }
 
 class CompleteResponse {
@@ -90,9 +90,9 @@ class CompleteResponse {
 
   final List<Map<String, String>> completions;
 
-  CompleteResponse() : this.byCompletions(0, 0, []);
-  CompleteResponse.byCompletions(this.replacementOffset, this.replacementLength,
-      List<Map> completions) :
+  CompleteResponse() : this.fromCompletions(0, 0, []);
+  CompleteResponse.fromCompletions(this.replacementOffset,
+    this.replacementLength, List<Map> completions) :
     this.completions = _convert(completions);
 
   /**
@@ -117,8 +117,8 @@ class CompleteResponse {
 class FixesResponse {
   final List<ProblemAndFixes> fixes;
 
-  FixesResponse() : this.byFixes([]);
-  FixesResponse.byFixes(List<AnalysisErrorFixes> analysisErrorFixes) :
+  FixesResponse() : this.fromFixes([]);
+  FixesResponse.fromFixes(List<AnalysisErrorFixes> analysisErrorFixes) :
     this.fixes = _convert(analysisErrorFixes);
 
   /**
@@ -152,7 +152,7 @@ class FixesResponse {
         }
 
         for (var sourceEdit in sourceFileEdit.edits) {
-          edits.add(new SourceEdit.byChanges(
+          edits.add(new SourceEdit.fromChanges(
               sourceEdit.offset,
               sourceEdit.length,
               sourceEdit.replacement));
@@ -160,11 +160,11 @@ class FixesResponse {
       }
       if (!invalidFix) {
         CandidateFix possibleFix = new
-          CandidateFix.byEdits(sourceChange.message, edits);
+          CandidateFix.fromEdits(sourceChange.message, edits);
         possibleFixes.add(possibleFix);
       }
     }
-    return new ProblemAndFixes.byList(
+    return new ProblemAndFixes.fromList(
         possibleFixes,
         problemMessage,
         problemOffset,
@@ -183,8 +183,8 @@ class ProblemAndFixes {
   final int offset;
   final int length;
 
-  ProblemAndFixes() : this.byList([]);
-  ProblemAndFixes.byList(
+  ProblemAndFixes() : this.fromList([]);
+  ProblemAndFixes.fromList(
       [this.fixes, this.problemMessage, this.offset, this.length]);
 }
 
@@ -195,8 +195,8 @@ class CandidateFix {
   final String message;
   final List<SourceEdit> edits;
 
-  CandidateFix() : this.byEdits();
-  CandidateFix.byEdits([this.message, this.edits]);
+  CandidateFix() : this.fromEdits();
+  CandidateFix.fromEdits([this.message, this.edits]);
 }
 
 /**
@@ -210,8 +210,8 @@ class FormatResponse {
       description: 'The (optional) new offset of the cursor; can be `null`.')
   final int offset;
 
-  FormatResponse() : this.byCode("");
-  FormatResponse.byCode(this.newString, [this.offset = 0]);
+  FormatResponse() : this.fromCode("");
+  FormatResponse.fromCode(this.newString, [this.offset = 0]);
 }
 
 /**
@@ -222,8 +222,8 @@ class SourceEdit {
   final int length;
   final String replacement;
 
-  SourceEdit() : this.byChanges();
-  SourceEdit.byChanges([this.offset, this.length, this.replacement]);
+  SourceEdit() : this.fromChanges();
+  SourceEdit.fromChanges([this.offset, this.length, this.replacement]);
 
   String applyTo(String target) {
     if (offset >= replacement.length) {

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -67,13 +67,18 @@ class CounterRequest {
 class CounterResponse {
   final int count;
 
-  CounterResponse(this.count);
+  CounterResponse({this.count : 0});
+//  {
+//    count = 0;
+//  }
+//
+//  CounterResponse.ByCount(this.count);
 }
 
 class DocumentResponse {
   final Map<String, String> info;
 
-  DocumentResponse(this.info);
+  DocumentResponse([this.info]);
 }
 
 class CompleteResponse {
@@ -85,8 +90,8 @@ class CompleteResponse {
 
   final List<Map<String, String>> completions;
 
-  CompleteResponse(this.replacementOffset, this.replacementLength,
-      List<Map> completions) :
+  CompleteResponse([this.replacementOffset, this.replacementLength,
+      List<Map> completions]) :
     this.completions = _convert(completions);
 
   /**
@@ -175,7 +180,7 @@ class ProblemAndFixes {
   final int offset;
   final int length;
 
-  ProblemAndFixes(this.fixes, this.problemMessage, this.offset, this.length);
+  ProblemAndFixes([this.fixes, this.problemMessage, this.offset, this.length]);
 }
 
 /**
@@ -185,7 +190,7 @@ class CandidateFix {
   final String message;
   final List<SourceEdit> edits;
 
-  CandidateFix(this.message, this.edits);
+  CandidateFix([this.message, this.edits]);
 }
 
 /**
@@ -210,7 +215,7 @@ class SourceEdit {
   final int length;
   final String replacement;
 
-  SourceEdit(this.offset, this.length, this.replacement);
+  SourceEdit([this.offset, this.length, this.replacement]);
 
   String applyTo(String target) {
     if (offset >= replacement.length) {

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -13,7 +13,8 @@ import 'package:rpc/rpc.dart';
 class AnalysisResults {
   final List<AnalysisIssue> issues;
 
-  AnalysisResults(this.issues);
+  AnalysisResults() : this.byIssues([]);
+  AnalysisResults.byIssues(this.issues);
 }
 
 class AnalysisIssue implements Comparable {
@@ -27,7 +28,8 @@ class AnalysisIssue implements Comparable {
   final int charLength;
   final String location;
 
-  AnalysisIssue(this.kind, this.line, this.message,
+  AnalysisIssue() : this.byIssue("", 0, "");
+  AnalysisIssue.byIssue(this.kind, this.line, this.message,
       {this.charStart, this.charLength, this.location, this.hasFixes: false});
 
   Map toMap() {
@@ -56,7 +58,8 @@ class SourceRequest {
 class CompileResponse {
   final String result;
 
-  CompileResponse(this.result);
+  CompileResponse() : this.byResponse("");
+  CompileResponse.byResponse(this.result);
 }
 
 class CounterRequest {
@@ -67,18 +70,15 @@ class CounterRequest {
 class CounterResponse {
   final int count;
 
-  CounterResponse({this.count : 0});
-//  {
-//    count = 0;
-//  }
-//
-//  CounterResponse.ByCount(this.count);
+  CounterResponse() : this.byCount(0);
+  CounterResponse.byCount(this.count);
 }
 
 class DocumentResponse {
   final Map<String, String> info;
 
-  DocumentResponse([this.info]);
+  DocumentResponse() : this.byInfo();
+  DocumentResponse.byInfo([this.info]);
 }
 
 class CompleteResponse {
@@ -90,8 +90,9 @@ class CompleteResponse {
 
   final List<Map<String, String>> completions;
 
-  CompleteResponse([this.replacementOffset, this.replacementLength,
-      List<Map> completions]) :
+  CompleteResponse() : this.byCompletions(0, 0, []);
+  CompleteResponse.byCompletions(this.replacementOffset, this.replacementLength,
+      List<Map> completions) :
     this.completions = _convert(completions);
 
   /**
@@ -116,7 +117,8 @@ class CompleteResponse {
 class FixesResponse {
   final List<ProblemAndFixes> fixes;
 
-  FixesResponse(List<AnalysisErrorFixes> analysisErrorFixes) :
+  FixesResponse() : this.byFixes([]);
+  FixesResponse.byFixes(List<AnalysisErrorFixes> analysisErrorFixes) :
     this.fixes = _convert(analysisErrorFixes);
 
   /**
@@ -150,18 +152,19 @@ class FixesResponse {
         }
 
         for (var sourceEdit in sourceFileEdit.edits) {
-          edits.add(new SourceEdit(
+          edits.add(new SourceEdit.byChanges(
               sourceEdit.offset,
               sourceEdit.length,
               sourceEdit.replacement));
         }
       }
       if (!invalidFix) {
-        CandidateFix possibleFix = new CandidateFix(sourceChange.message, edits);
+        CandidateFix possibleFix = new
+          CandidateFix.byEdits(sourceChange.message, edits);
         possibleFixes.add(possibleFix);
       }
     }
-    return new ProblemAndFixes(
+    return new ProblemAndFixes.byList(
         possibleFixes,
         problemMessage,
         problemOffset,
@@ -180,7 +183,9 @@ class ProblemAndFixes {
   final int offset;
   final int length;
 
-  ProblemAndFixes([this.fixes, this.problemMessage, this.offset, this.length]);
+  ProblemAndFixes() : this.byList([]);
+  ProblemAndFixes.byList(
+      [this.fixes, this.problemMessage, this.offset, this.length]);
 }
 
 /**
@@ -190,7 +195,8 @@ class CandidateFix {
   final String message;
   final List<SourceEdit> edits;
 
-  CandidateFix([this.message, this.edits]);
+  CandidateFix() : this.byEdits();
+  CandidateFix.byEdits([this.message, this.edits]);
 }
 
 /**
@@ -204,7 +210,8 @@ class FormatResponse {
       description: 'The (optional) new offset of the cursor; can be `null`.')
   final int offset;
 
-  FormatResponse(this.newString, [this.offset = 0]);
+  FormatResponse() : this.byCode("");
+  FormatResponse.byCode(this.newString, [this.offset = 0]);
 }
 
 /**
@@ -215,7 +222,8 @@ class SourceEdit {
   final int length;
   final String replacement;
 
-  SourceEdit([this.offset, this.length, this.replacement]);
+  SourceEdit() : this.byChanges();
+  SourceEdit.byChanges([this.offset, this.length, this.replacement]);
 
   String applyTo(String target) {
     if (offset >= replacement.length) {

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -77,7 +77,7 @@ class CommonServer {
   @ApiMethod(method: 'GET', path: 'counter')
   Future<CounterResponse> counterGet({String name}) {
     return counter.getTotal(name).then((total) {
-      return new CounterResponse(total);
+      return new CounterResponse.byCount(total);
     });
   }
 
@@ -230,7 +230,7 @@ class CommonServer {
     return checkCache("%%COMPILE:$sourceHash").then((String result) {
       if (!suppressCache && result != null) {
         _logger.info("CACHE: Cache hit for compile");
-        return new CompileResponse(result);
+        return new CompileResponse.byResponse(result);
       } else {
         _logger.info("CACHE: MISS, forced: $suppressCache");
         Stopwatch watch = new Stopwatch()..start();
@@ -247,7 +247,7 @@ class CommonServer {
             counter.increment("Compiled-Lines", increment: lineCount);
             String out = results.getOutput();
             return setCache("%%COMPILE:$sourceHash", out).then((_) {
-              return new CompileResponse(out);
+              return new CompileResponse.byResponse(out);
             });
           } else {
             List problems = _filterCompileProblems(results.problems);
@@ -279,7 +279,7 @@ class CommonServer {
           _logger.info(
             'PERF: Computed dartdoc in ${watch.elapsedMilliseconds}ms.');
           counter.increment("DartDocs");
-          return new DocumentResponse(docInfo);
+          return new DocumentResponse.byInfo(docInfo);
         }).catchError((e, st) {
           _logger.severe('Error during dartdoc: ${e}\n${st}');
           throw e;
@@ -312,7 +312,7 @@ class CommonServer {
 
     if (analysisResults.issues.where(
       (issue) => issue.kind == "error").length > 0) {
-      return new FormatResponse(source, offset);
+      return new FormatResponse.byCode(source, offset);
     }
     return analysisServer.format(source, offset);
   }

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -77,7 +77,7 @@ class CommonServer {
   @ApiMethod(method: 'GET', path: 'counter')
   Future<CounterResponse> counterGet({String name}) {
     return counter.getTotal(name).then((total) {
-      return new CounterResponse.byCount(total);
+      return new CounterResponse.fromCount(total);
     });
   }
 
@@ -230,7 +230,7 @@ class CommonServer {
     return checkCache("%%COMPILE:$sourceHash").then((String result) {
       if (!suppressCache && result != null) {
         _logger.info("CACHE: Cache hit for compile");
-        return new CompileResponse.byResponse(result);
+        return new CompileResponse.fromResponse(result);
       } else {
         _logger.info("CACHE: MISS, forced: $suppressCache");
         Stopwatch watch = new Stopwatch()..start();
@@ -247,7 +247,7 @@ class CommonServer {
             counter.increment("Compiled-Lines", increment: lineCount);
             String out = results.getOutput();
             return setCache("%%COMPILE:$sourceHash", out).then((_) {
-              return new CompileResponse.byResponse(out);
+              return new CompileResponse.fromResponse(out);
             });
           } else {
             List problems = _filterCompileProblems(results.problems);
@@ -279,7 +279,7 @@ class CommonServer {
           _logger.info(
             'PERF: Computed dartdoc in ${watch.elapsedMilliseconds}ms.');
           counter.increment("DartDocs");
-          return new DocumentResponse.byInfo(docInfo);
+          return new DocumentResponse.fromInfo(docInfo);
         }).catchError((e, st) {
           _logger.severe('Error during dartdoc: ${e}\n${st}');
           throw e;
@@ -312,7 +312,7 @@ class CommonServer {
 
     if (analysisResults.issues.where(
       (issue) => issue.kind == "error").length > 0) {
-      return new FormatResponse.byCode(source, offset);
+      return new FormatResponse.fromCode(source, offset);
     }
     return analysisServer.format(source, offset);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     git:
       url: git://github.com/lukechurch/dart_style.git
 #  analyzer: '>=0.22.4 <0.23.0'
-  appengine: '>=0.2.6 <0.3.0'
+  appengine: ^0.3.0
   archive: '>=1.0.19 <1.1.0'
   args: '>=0.12.0 <0.14.0'
   cli_util: ^0.0.1
@@ -29,7 +29,7 @@ dependencies:
   shelf: ^0.6.0
   shelf_cors: ^0.2.0
   shelf_route: ^0.12.0
-  rpc: ^0.2.0
+  rpc: ^0.4.1
   yaml: ^2.0.0
 dev_dependencies:
   _discoveryapis_commons: any

--- a/test/api_classes_test.dart
+++ b/test/api_classes_test.dart
@@ -10,7 +10,7 @@ import 'package:unittest/unittest.dart';
 void defineTests() {
   group('AnalysisIssue', () {
     test('toMap', () {
-      AnalysisIssue issue = new AnalysisIssue.byIssue(
+      AnalysisIssue issue = new AnalysisIssue.fromIssue(
           'error', 1, 'not found', charStart: 123);
       Map m = issue.toMap();
       expect(m['kind'], 'error');
@@ -21,7 +21,7 @@ void defineTests() {
     });
 
     test('toString', () {
-      AnalysisIssue issue = new AnalysisIssue.byIssue('error', 1, 'not found');
+      AnalysisIssue issue = new AnalysisIssue.fromIssue('error', 1, 'not found');
       expect(issue.toString(), isNotNull);
     });
   });

--- a/test/api_classes_test.dart
+++ b/test/api_classes_test.dart
@@ -10,7 +10,7 @@ import 'package:unittest/unittest.dart';
 void defineTests() {
   group('AnalysisIssue', () {
     test('toMap', () {
-      AnalysisIssue issue = new AnalysisIssue(
+      AnalysisIssue issue = new AnalysisIssue.byIssue(
           'error', 1, 'not found', charStart: 123);
       Map m = issue.toMap();
       expect(m['kind'], 'error');
@@ -21,7 +21,7 @@ void defineTests() {
     });
 
     test('toString', () {
-      AnalysisIssue issue = new AnalysisIssue('error', 1, 'not found');
+      AnalysisIssue issue = new AnalysisIssue.byIssue('error', 1, 'not found');
       expect(issue.toString(), isNotNull);
     });
   });

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -46,15 +46,17 @@ void defineTests() {
 
   Future<HttpApiResponse> _sendPostRequest(String path, json) {
     assert(apiServer != null);
+    var uri = Uri.parse("http://localhost/$path");
     var body = new Stream.fromIterable([UTF8.encode(JSON.encode(json))]);
-    var request = new HttpApiRequest('POST', path, {}, {}, body);
+    var request = new HttpApiRequest('POST', uri, {}, body);
     return apiServer.handleHttpApiRequest(request);
   }
 
   Future<HttpApiResponse> _sendGetRequest(String path, Map queryParams) {
     assert(apiServer != null);
+    var uri = Uri.parse("http://localhost/$path");
     var body = new Stream.fromIterable([]);
-    var request = new HttpApiRequest('GET', path, queryParams, {}, body);
+    var request = new HttpApiRequest('GET', uri, {}, body);
     return apiServer.handleHttpApiRequest(request);
   }
 
@@ -67,7 +69,7 @@ void defineTests() {
       counter = new MockCounter();
 
       server = new CommonServer(sdkPath, cache, recorder, counter);
-      apiServer = new ApiServer('/api', prettyPrint: true)..addApi(server);
+      apiServer = new ApiServer(apiPrefix: '/api', prettyPrint: true)..addApi(server);
       return server.warmup();
     });
 

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -199,7 +199,7 @@ void defineTests() {
 
     test('counter test', () async {
       var response =
-        await _sendGetRequest('dartservices/v1/counter', {"name" : "Analyses"});
+        await _sendGetRequest('dartservices/v1/counter', "name=Analyses");
       var data = JSON.decode(UTF8.decode(await response.body.first));
       expect(response.status, 200);
       expect(data['count'], 0);

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -46,7 +46,7 @@ void defineTests() {
 
   Future<HttpApiResponse> _sendPostRequest(String path, json) {
     assert(apiServer != null);
-    var uri = Uri.parse("http://localhost/$path");
+    var uri = Uri.parse("/api/$path");
     var body = new Stream.fromIterable([UTF8.encode(JSON.encode(json))]);
     var request = new HttpApiRequest('POST', uri, {}, body);
     return apiServer.handleHttpApiRequest(request);
@@ -54,7 +54,7 @@ void defineTests() {
 
   Future<HttpApiResponse> _sendGetRequest(String path, Map queryParams) {
     assert(apiServer != null);
-    var uri = Uri.parse("http://localhost/$path");
+    var uri = Uri.parse("/api/$path");
     var body = new Stream.fromIterable([]);
     var request = new HttpApiRequest('GET', uri, {}, body);
     return apiServer.handleHttpApiRequest(request);

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -52,9 +52,9 @@ void defineTests() {
     return apiServer.handleHttpApiRequest(request);
   }
 
-  Future<HttpApiResponse> _sendGetRequest(String path, Map queryParams) {
+  Future<HttpApiResponse> _sendGetRequest(String path, String queryParams) {
     assert(apiServer != null);
-    var uri = Uri.parse("/api/$path");
+    var uri = Uri.parse("/api/$path?$queryParams");
     var body = new Stream.fromIterable([]);
     var request = new HttpApiRequest('GET', uri, {}, body);
     return apiServer.handleHttpApiRequest(request);
@@ -209,7 +209,7 @@ void defineTests() {
       response = await _sendPostRequest('dartservices/v1/analyze', json);
 
       response =
-        await _sendGetRequest('dartservices/v1/counter', {"name" : "Analyses"});
+        await _sendGetRequest('dartservices/v1/counter', "name=Analyses");
       data = JSON.decode(UTF8.decode(await response.body.first));
       expect(response.status, 200);
       expect(data['count'], 1);

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -101,7 +101,7 @@ setupTools(String sdkPath) async {
   recorder = new MockRequestRecorder();
   counter = new MockCounter();
   server = new CommonServer(sdkPath, cache, recorder, counter);
-  apiServer = new ApiServer('/api', prettyPrint: true)..addApi(server);
+  apiServer = new ApiServer(apiPrefix: '/api', prettyPrint: true)..addApi(server);
 
   analysisServer = new analysis_server.AnalysisServerWrapper(sdkPath);
   await analysisServer.warmup();


### PR DESCRIPTION
@wibling PTAL - This is the transition from RPC v2 -> v4

If I don't put in the no-arg ctors, the generator returns failures. This degrades the readability of the API quite a bit, as in a lot of cases these result carrying classes don't make sense without arguments. Is there anything we could do here to avoid the need for these empty ctors?

Fixes #169 