### PR TITLE
add a /version service call

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -566,7 +566,7 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method  will complete with the same error.
    */
-  async.Future<VersionResponse> sdkVersion() {
+  async.Future<VersionResponse> version() {
     var _url = null;
     var _queryParams = new core.Map();
     var _uploadMedia = null;
@@ -576,7 +576,7 @@ class DartservicesApi {
 
 
 
-    _url = 'sdkVersion';
+    _url = 'version';
 
     var _response = _requester.request(_url,
                                        "GET",
@@ -991,21 +991,55 @@ class SourceRequest {
 
 
 class VersionResponse {
-  core.String version;
+  /** The version of App Engine that the server is running on. */
+  core.String appEngineVersion;
+
+  /**
+   * The version of the Dart SDK that the server is running on. This will start
+   * with a semver string, and have a space and other build details appended.
+   */
+  core.String runtimeVersion;
+
+  /**
+   * The version of the Dart SDK that DartPad is compatible with. This will be a
+   * semver string.
+   */
+  core.String sdkVersion;
+
+  /** The version of the dart-services backend. */
+  core.String servicesVersion;
 
 
   VersionResponse();
 
   VersionResponse.fromJson(core.Map _json) {
-    if (_json.containsKey("version")) {
-      version = _json["version"];
+    if (_json.containsKey("appEngineVersion")) {
+      appEngineVersion = _json["appEngineVersion"];
+    }
+    if (_json.containsKey("runtimeVersion")) {
+      runtimeVersion = _json["runtimeVersion"];
+    }
+    if (_json.containsKey("sdkVersion")) {
+      sdkVersion = _json["sdkVersion"];
+    }
+    if (_json.containsKey("servicesVersion")) {
+      servicesVersion = _json["servicesVersion"];
     }
   }
 
   core.Map toJson() {
     var _json = new core.Map();
-    if (version != null) {
-      _json["version"] = version;
+    if (appEngineVersion != null) {
+      _json["appEngineVersion"] = appEngineVersion;
+    }
+    if (runtimeVersion != null) {
+      _json["runtimeVersion"] = runtimeVersion;
+    }
+    if (sdkVersion != null) {
+      _json["sdkVersion"] = sdkVersion;
+    }
+    if (servicesVersion != null) {
+      _json["servicesVersion"] = servicesVersion;
     }
     return _json;
   }

--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -554,7 +554,7 @@ class DartservicesApi {
   }
 
   /**
-   * Return the current SDK version for DartPad.
+   * Return the current SDK version for DartServices.
    *
    * Request parameters:
    *
@@ -991,22 +991,22 @@ class SourceRequest {
 
 
 class VersionResponse {
-  /** The version of App Engine that the server is running on. */
+  /** The App Engine version. */
   core.String appEngineVersion;
 
   /**
-   * The version of the Dart SDK that the server is running on. This will start
-   * with a semver string, and have a space and other build details appended.
+   * The Dart SDK version that the server is running on. This will start with a
+   * semver string, and have a space and other build details appended.
    */
   core.String runtimeVersion;
 
   /**
-   * The version of the Dart SDK that DartPad is compatible with. This will be a
+   * The Dart SDK version that DartServices is compatible with. This will be a
    * semver string.
    */
   core.String sdkVersion;
 
-  /** The version of the dart-services backend. */
+  /** The dart-services backend version. */
   core.String servicesVersion;
 
 

--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -553,6 +553,41 @@ class DartservicesApi {
     return _response.then((data) => new FormatResponse.fromJson(data));
   }
 
+  /**
+   * Return the current SDK version for DartPad.
+   *
+   * Request parameters:
+   *
+   * Completes with a [VersionResponse].
+   *
+   * Completes with a [commons.ApiRequestError] if the API endpoint returned an
+   * error.
+   *
+   * If the used [http.Client] completes with an error when making a REST call,
+   * this method  will complete with the same error.
+   */
+  async.Future<VersionResponse> sdkVersion() {
+    var _url = null;
+    var _queryParams = new core.Map();
+    var _uploadMedia = null;
+    var _uploadOptions = null;
+    var _downloadOptions = commons.DownloadOptions.Metadata;
+    var _body = null;
+
+
+
+    _url = 'sdkVersion';
+
+    var _response = _requester.request(_url,
+                                       "GET",
+                                       body: _body,
+                                       queryParams: _queryParams,
+                                       uploadOptions: _uploadOptions,
+                                       uploadMedia: _uploadMedia,
+                                       downloadOptions: _downloadOptions);
+    return _response.then((data) => new VersionResponse.fromJson(data));
+  }
+
 }
 
 
@@ -949,6 +984,28 @@ class SourceRequest {
     }
     if (source != null) {
       _json["source"] = source;
+    }
+    return _json;
+  }
+}
+
+
+class VersionResponse {
+  core.String version;
+
+
+  VersionResponse();
+
+  VersionResponse.fromJson(core.Map _json) {
+    if (_json.containsKey("version")) {
+      version = _json["version"];
+    }
+  }
+
+  core.Map toJson() {
+    var _json = new core.Map();
+    if (version != null) {
+      _json["version"] = version;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "1921d142520d08e6023eeb4f51f68bfb0535158e",
+ "etag": "12fa0452d0b98182f08537636be1dc655d4a7b13",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -213,8 +213,21 @@
    "id": "VersionResponse",
    "type": "object",
    "properties": {
-    "version": {
-     "type": "string"
+    "sdkVersion": {
+     "type": "string",
+     "description": "The version of the Dart SDK that DartPad is compatible with. This will be a semver string."
+    },
+    "runtimeVersion": {
+     "type": "string",
+     "description": "The version of the Dart SDK that the server is running on. This will start with a semver string, and have a space and other build details appended."
+    },
+    "appEngineVersion": {
+     "type": "string",
+     "description": "The version of App Engine that the server is running on."
+    },
+    "servicesVersion": {
+     "type": "string",
+     "description": "The version of the dart-services backend."
     }
    }
   }
@@ -447,9 +460,9 @@
     "$ref": "DocumentResponse"
    }
   },
-  "sdkVersion": {
-   "id": "CommonServer.sdkVersion",
-   "path": "sdkVersion",
+  "version": {
+   "id": "CommonServer.version",
+   "path": "version",
    "httpMethod": "GET",
    "description": "Return the current SDK version for DartPad.",
    "parameters": {},

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "12fa0452d0b98182f08537636be1dc655d4a7b13",
+ "etag": "df13a4702aece7090e3c9bd7f3a42204b88707aa",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -215,19 +215,19 @@
    "properties": {
     "sdkVersion": {
      "type": "string",
-     "description": "The version of the Dart SDK that DartPad is compatible with. This will be a semver string."
+     "description": "The Dart SDK version that DartServices is compatible with. This will be a semver string."
     },
     "runtimeVersion": {
      "type": "string",
-     "description": "The version of the Dart SDK that the server is running on. This will start with a semver string, and have a space and other build details appended."
+     "description": "The Dart SDK version that the server is running on. This will start with a semver string, and have a space and other build details appended."
     },
     "appEngineVersion": {
      "type": "string",
-     "description": "The version of App Engine that the server is running on."
+     "description": "The App Engine version."
     },
     "servicesVersion": {
      "type": "string",
-     "description": "The version of the dart-services backend."
+     "description": "The dart-services backend version."
     }
    }
   }
@@ -464,7 +464,7 @@
    "id": "CommonServer.version",
    "path": "version",
    "httpMethod": "GET",
-   "description": "Return the current SDK version for DartPad.",
+   "description": "Return the current SDK version for DartServices.",
    "parameters": {},
    "parameterOrder": [],
    "response": {

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "bd4e8cff8c987967ead41a32e025116cb6637f6f",
+ "etag": "1921d142520d08e6023eeb4f51f68bfb0535158e",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -206,6 +206,15 @@
      "additionalProperties": {
       "type": "string"
      }
+    }
+   }
+  },
+  "VersionResponse": {
+   "id": "VersionResponse",
+   "type": "object",
+   "properties": {
+    "version": {
+     "type": "string"
     }
    }
   }
@@ -436,6 +445,17 @@
    "parameterOrder": [],
    "response": {
     "$ref": "DocumentResponse"
+   }
+  },
+  "sdkVersion": {
+   "id": "CommonServer.sdkVersion",
+   "path": "sdkVersion",
+   "httpMethod": "GET",
+   "description": "Return the current SDK version for DartPad.",
+   "parameters": {},
+   "parameterOrder": [],
+   "response": {
+    "$ref": "VersionResponse"
    }
   }
  },

--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -52,6 +52,7 @@ class GaeServer {
     discoveryEnabled = false;
     commonServer = new CommonServer(
         sdkPath,
+        new GaeServerContainer(),
         new GaeCache(),
         new GaeSourceRequestRecorder(),
         new GaeCounter());
@@ -110,6 +111,10 @@ class GaeServer {
                        ..close();
     }
   }
+}
+
+class GaeServerContainer implements ServerContainer {
+  String get version => ae.context.services.modules.currentVersion;
 }
 
 class GaeCache implements ServerCache {

--- a/lib/services_server.dart
+++ b/lib/services_server.dart
@@ -17,6 +17,7 @@ import 'package:shelf/shelf_io.dart' as shelf;
 import 'package:shelf_cors/shelf_cors.dart' as shelf_cors;
 import 'package:shelf_route/shelf_route.dart';
 
+import 'src/common.dart';
 import 'src/common_server.dart';
 
 const Map _textPlainHeader = const {HttpHeaders.CONTENT_TYPE: 'text/plain'};
@@ -77,6 +78,7 @@ class EndpointsServer {
                                           String serverUrl) async {
     var commonServer = new CommonServer(
         sdkPath,
+        new _ServerContainer(),
         new _Cache(),
         new _Recorder(),
         new _Counter());
@@ -109,6 +111,7 @@ class EndpointsServer {
     discoveryEnabled = false;
     commonServer = new CommonServer(
         sdkPath,
+        new _ServerContainer(),
         new _Cache(),
         new _Recorder(),
         new _Counter());
@@ -158,6 +161,10 @@ View the available API calls at /api/discovery/v1/apis/dartservices/v1/rest.
       'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept'
     });
   }
+}
+
+class _ServerContainer implements ServerContainer {
+  String get version => vmVersion;
 }
 
 class _Cache implements ServerCache {

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -238,9 +238,29 @@ class SourceEdit {
   }
 }
 
+/// The response from the `/version` service call.
 class VersionResponse {
-  final String version;
+  @ApiProperty(
+      description: 'The Dart SDK version that DartPad is compatible with. This '
+        'will be a semver string.')
+  final String sdkVersion;
 
-  VersionResponse() : version = null;
-  VersionResponse.fromVersion(this.version);
+  @ApiProperty(
+      description: 'The Dart SDK version that the server is running on. This '
+        'will start with a semver string, and have a space and other build '
+        'details appended.')
+  final String runtimeVersion;
+
+  @ApiProperty(
+      description: 'The App Engine version.')
+  final String appEngineVersion;
+
+  @ApiProperty(
+      description: 'The dart-services backend version.')
+  final String servicesVersion;
+
+  VersionResponse() : sdkVersion = null, runtimeVersion = null,
+      appEngineVersion = null, servicesVersion = null;
+  VersionResponse.from({this.sdkVersion, this.runtimeVersion,
+    this.appEngineVersion, this.servicesVersion});
 }

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -241,8 +241,8 @@ class SourceEdit {
 /// The response from the `/version` service call.
 class VersionResponse {
   @ApiProperty(
-      description: 'The Dart SDK version that DartPad is compatible with. This '
-        'will be a semver string.')
+      description: 'The Dart SDK version that DartServices is compatible with. '
+        'This will be a semver string.')
   final String sdkVersion;
 
   @ApiProperty(

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -237,3 +237,10 @@ class SourceEdit {
     return "$pre$replacement$post";
   }
 }
+
+class VersionResponse {
+  final String version;
+
+  VersionResponse() : version = null;
+  VersionResponse.fromVersion(this.version);
+}

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -4,6 +4,8 @@
 
 library services.common;
 
+import 'dart:io';
+
 final String sampleCode = """
 void main() {
   print("hello");
@@ -63,6 +65,15 @@ class Lines {
     return _starts.length;
   }
 }
+
+/**
+ * Returns the version of the current Dart runtime.
+ *
+ * The returned `String` is formatted as the [semver](http://semver.org) version
+ * string of the current Dart runtime, possibly followed by whitespace and other
+ * version and build details.
+ */
+String get vmVersion => Platform.version;
 
 /// If [str] has leading and trailing quotes, remove them.
 String stripMatchingQuotes(String str) {

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -190,6 +190,12 @@ class CommonServer {
     return _document(source, offset);
   }
 
+  @ApiMethod(
+      method: 'GET',
+      path: 'sdkVersion',
+      description: 'Return the current SDK version for DartPad.')
+  Future<VersionResponse> sdkVersion() => new Future.value(_sdkVersion());
+
   Future<AnalysisResults> _analyze(String source) async {
     if (source == null) {
       throw new BadRequestError('Missing parameter: \'source\'');
@@ -289,6 +295,8 @@ class CommonServer {
       throw e;
     }
   }
+
+  VersionResponse _sdkVersion() => new VersionResponse.fromVersion(compiler.version);
 
   Future<CompleteResponse> _complete(String source, int offset) async {
     srcRequestRecorder.record("COMPLETE", source, offset);

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -201,7 +201,7 @@ class CommonServer {
   @ApiMethod(
       method: 'GET',
       path: 'version',
-      description: 'Return the current SDK version for DartPad.')
+      description: 'Return the current SDK version for DartServices.')
   Future<VersionResponse> version() => new Future.value(_version());
 
   Future<AnalysisResults> _analyze(String source) async {

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -11,6 +11,7 @@ import 'dart:async';
 
 import 'package:compiler_unsupported/compiler.dart' as compiler;
 import 'package:compiler_unsupported/sdk_io.dart' as sdk;
+import 'package:compiler_unsupported/version.dart' as compilerVersion;
 import 'package:logging/logging.dart';
 
 import 'common.dart';
@@ -31,6 +32,9 @@ class Compiler {
   final Pub pub;
 
   Compiler(String sdkPath, [this.pub]) : _sdk = new sdk.DartSdkIO();
+
+  /// The version of the SDK this copy of dart2js is based on.
+  String get version => compilerVersion.version;
 
   Future warmup([bool useHtml = false]) =>
       compile(useHtml ? sampleCodeWeb : sampleCode);

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// TODO: We need a build process to update this number. Something like a grinder
+// task that will stamp the source file as part of a deploy, or a milestone task.
+
+/// The version of the dart-services backend.
+const String servicesVersion = "M1.0";

--- a/test/common_test.dart
+++ b/test/common_test.dart
@@ -47,4 +47,9 @@ void defineTests() {
     expect(stripMatchingQuotes('""'), '');
     expect(stripMatchingQuotes('"abc"'), 'abc');
   });
+
+  test('vmVersion', () {
+    expect(vmVersion, isNotNull);
+    expect(vmVersion, startsWith('1.'));
+  });
 }

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -25,6 +25,11 @@ void defineTests() {
       });
     });
 
+    test('version', () {
+      expect(compiler.version, isNotNull);
+      expect(compiler.version, startsWith('1.'));
+    });
+
     test('simple web', () {
       return compiler.compile(sampleCodeWeb).then((CompilationResults result) {
         expect(result.success, true);

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:services/src/analysis_server.dart' as analysis_server;
 import 'package:services/src/analyzer.dart' as ana;
+import 'package:services/src/common.dart';
 import 'package:services/src/compiler.dart' as comp;
 
 import 'package:services/src/common_server.dart';
@@ -26,6 +27,7 @@ bool _SERVER_BASED_CALL = false;
 
 CommonServer server;
 ApiServer apiServer;
+MockContainer container;
 MockCache cache;
 MockRequestRecorder recorder;
 MockCounter counter;
@@ -104,10 +106,11 @@ Usage: slow_test path_to_test_collection
  * Init the tools, and warm them up
  */
 setupTools(String sdkPath) async {
+  container = new MockContainer();
   cache = new MockCache();
   recorder = new MockRequestRecorder();
   counter = new MockCounter();
-  server = new CommonServer(sdkPath, cache, recorder, counter);
+  server = new CommonServer(sdkPath, container, cache, recorder, counter);
   apiServer = new ApiServer(apiPrefix: '/api', prettyPrint: true)..addApi(server);
 
   analysisServer = new analysis_server.AnalysisServerWrapper(sdkPath);
@@ -274,6 +277,10 @@ String mutate(String src) {
   if (i == 0) i = 1;
   String newStr = src.substring(0, i - 1) + s + src.substring(i);
   return newStr;
+}
+
+class MockContainer implements ServerContainer {
+  String get version => vmVersion;
 }
 
 class MockCache implements ServerCache {


### PR DESCRIPTION
Fix #185 

@lukechurch 

Should the service call be called `/sdkVersion`? `/version`? I don't want people to confuse the sdk version and a dartpad version. Perhaps call it `/version` and have it return a few different versions in the result object.