### PR TITLE
compile in checked mode; return source maps

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -117,7 +117,7 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method  will complete with the same error.
    */
-  async.Future<CompileResponse> compile(SourceRequest request) {
+  async.Future<CompileResponse> compile(CompileRequest request) {
     var _url = null;
     var _queryParams = new core.Map();
     var _uploadMedia = null;
@@ -679,8 +679,53 @@ class CandidateFix {
 }
 
 
+class CompileRequest {
+  /** Return the Dart to JS source map; optional (defaults to false). */
+  core.bool returnSourceMap;
+
+  /** The Dart source. */
+  core.String source;
+
+  /**
+   * Compile to code with checked mode checks; optional (defaults to false).
+   */
+  core.bool useCheckedMode;
+
+
+  CompileRequest();
+
+  CompileRequest.fromJson(core.Map _json) {
+    if (_json.containsKey("returnSourceMap")) {
+      returnSourceMap = _json["returnSourceMap"];
+    }
+    if (_json.containsKey("source")) {
+      source = _json["source"];
+    }
+    if (_json.containsKey("useCheckedMode")) {
+      useCheckedMode = _json["useCheckedMode"];
+    }
+  }
+
+  core.Map toJson() {
+    var _json = new core.Map();
+    if (returnSourceMap != null) {
+      _json["returnSourceMap"] = returnSourceMap;
+    }
+    if (source != null) {
+      _json["source"] = source;
+    }
+    if (useCheckedMode != null) {
+      _json["useCheckedMode"] = useCheckedMode;
+    }
+    return _json;
+  }
+}
+
+
 class CompileResponse {
   core.String result;
+
+  core.String sourceMap;
 
 
   CompileResponse();
@@ -689,12 +734,18 @@ class CompileResponse {
     if (_json.containsKey("result")) {
       result = _json["result"];
     }
+    if (_json.containsKey("sourceMap")) {
+      sourceMap = _json["sourceMap"];
+    }
   }
 
   core.Map toJson() {
     var _json = new core.Map();
     if (result != null) {
       _json["result"] = result;
+    }
+    if (sourceMap != null) {
+      _json["sourceMap"] = sourceMap;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "bd4e8cff8c987967ead41a32e025116cb6637f6f",
+ "etag": "a82c90329571bcd394386053e89fd6e6b0ca7bfc",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -81,11 +81,33 @@
     }
    }
   },
+  "CompileRequest": {
+   "id": "CompileRequest",
+   "type": "object",
+   "properties": {
+    "source": {
+     "type": "string",
+     "description": "The Dart source.",
+     "required": true
+    },
+    "useCheckedMode": {
+     "type": "boolean",
+     "description": "Compile to code with checked mode checks; optional (defaults to false)."
+    },
+    "returnSourceMap": {
+     "type": "boolean",
+     "description": "Return the Dart to JS source map; optional (defaults to false)."
+    }
+   }
+  },
   "CompileResponse": {
    "id": "CompileResponse",
    "type": "object",
    "properties": {
     "result": {
+     "type": "string"
+    },
+    "sourceMap": {
      "type": "string"
     }
    }
@@ -267,7 +289,7 @@
    "parameters": {},
    "parameterOrder": [],
    "request": {
-    "$ref": "SourceRequest"
+    "$ref": "CompileRequest"
    },
    "response": {
     "$ref": "CompileResponse"

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -55,11 +55,28 @@ class SourceRequest {
   int offset;
 }
 
+class CompileRequest {
+  @ApiProperty(
+      required: true,
+      description: 'The Dart source.')
+  String source;
+
+  @ApiProperty(
+      description: 'Compile to code with checked mode checks; optional '
+        '(defaults to false).')
+  bool useCheckedMode;
+
+  @ApiProperty(
+      description: 'Return the Dart to JS source map; optional (defaults to false).')
+  bool returnSourceMap;
+}
+
 class CompileResponse {
   final String result;
+  final String sourceMap;
 
-  CompileResponse() : this.fromResponse("");
-  CompileResponse.fromResponse(this.result);
+  CompileResponse() : this.fromResponse("", null);
+  CompileResponse.fromResponse(this.result, [this.sourceMap = null]);
 }
 
 class CounterRequest {

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -36,7 +36,8 @@ class Compiler {
       compile(useHtml ? sampleCodeWeb : sampleCode);
 
   /// Compile the given string and return the resulting [CompilationResults].
-  Future<CompilationResults> compile(String input) async {
+  Future<CompilationResults> compile(String input,
+      {bool useCheckedMode, bool returnSourceMap}) async {
     PubHelper pubHelper = null;
 
     if (pub != null) {
@@ -47,6 +48,16 @@ class Compiler {
     Lines lines = new Lines(input);
     CompilationResults result = new CompilationResults(lines);
 
+    List args = [];
+
+    if (useCheckedMode != null && useCheckedMode) {
+      args.add('--checked');
+    }
+
+    if (returnSourceMap == null || !returnSourceMap) {
+      args.add('--no-source-maps');
+    }
+
     // --incremental-support, --disable-type-inference
     return compiler.compile(
         provider.getInitialUri(),
@@ -54,8 +65,8 @@ class Compiler {
         new Uri(scheme: 'package', path: '/'),
         provider.inputProvider,
         result._diagnosticHandler,
-        ['--no-source-maps'],
-        result._outputProvider).then((_) {
+        args,
+        result._getOutputProvider).then((_) {
       result._problems.sort();
       return result;
     });
@@ -64,15 +75,18 @@ class Compiler {
 
 /// The result of a dart2js compile.
 class CompilationResults {
-  final StringBuffer _output = new StringBuffer();
+  final StringBuffer _compiledJS = new StringBuffer();
+  final StringBuffer _sourceMap = new StringBuffer();
   final List<CompilationProblem> _problems = [];
   final Lines _lines;
 
   CompilationResults(this._lines);
 
-  bool get hasOutput => _output.isNotEmpty;
+  bool get hasOutput => _compiledJS.isNotEmpty;
 
-  String getOutput() => _output.toString();
+  String getOutput() => _compiledJS.toString();
+
+  String getSourceMap() => _sourceMap.toString();
 
   List<CompilationProblem> get problems => _problems;
 
@@ -92,8 +106,10 @@ class CompilationResults {
     }
   }
 
-  EventSink<String> _outputProvider(String name, String extension) {
-    return extension == 'js' ? new _StringSink(_output) : new _NullSink();
+  EventSink<String> _getOutputProvider(String name, String extension) {
+    if (extension == 'js') return new _StringSink(_compiledJS);
+    if (extension == 'js.map') return new _StringSink(_sourceMap);
+    return new _NullSink();
   }
 }
 

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -22,8 +22,39 @@ void defineTests() {
     test('simple', () {
       return compiler.compile(sampleCode).then((CompilationResults result) {
         expect(result.success, true);
+        expect(result.getOutput(), isNotEmpty);
+        expect(result.getSourceMap(), isEmpty);
       });
     });
+
+    test('sourcemap', () {
+      return compiler.compile(sampleCode, returnSourceMap: true).then(
+          (CompilationResults result) {
+        expect(result.success, true);
+        expect(result.getOutput(), isNotEmpty);
+        expect(result.getSourceMap(), isNotEmpty);
+      });
+    });
+
+    // TODO: How to get different source when compiling with --checked?
+//    test('checked', () {
+//      final String sampleCodeChecked = '''
+//main() { foo(1); }
+//void foo(String bar) { print(bar); }
+//''';
+//
+//      String normal;
+//      String checked;
+//
+//      return compiler.compile(sampleCodeChecked).then((result) {
+//        normal = result.getOutput();
+//        return compiler.compile(sampleCodeChecked, useCheckedMode: true).then((result) {
+//          checked = result.getOutput();
+//
+//          expect(true, checked != normal);
+//        });
+//      });
+//    });
 
     test('simple web', () {
       return compiler.compile(sampleCodeWeb).then((CompilationResults result) {


### PR DESCRIPTION
fix #130, fix #129 

- return source maps for `/compile` (when requested, to save round trip time)
- compile in checked mode (when requested)

@lukechurch 
