### PR TITLE
upgrade rpc to 0.5.0

### DIFF
--- a/lib/services_server.dart
+++ b/lib/services_server.dart
@@ -17,7 +17,6 @@ import 'package:shelf/shelf_io.dart' as shelf;
 import 'package:shelf_cors/shelf_cors.dart' as shelf_cors;
 import 'package:shelf_route/shelf_route.dart';
 
-import 'src/common.dart';
 import 'src/common_server.dart';
 
 const Map _textPlainHeader = const {HttpHeaders.CONTENT_TYPE: 'text/plain'};
@@ -164,7 +163,7 @@ View the available API calls at /api/discovery/v1/apis/dartservices/v1/rest.
 }
 
 class _ServerContainer implements ServerContainer {
-  String get version => vmVersion;
+  String get version => '1.0';
 }
 
 class _Cache implements ServerCache {

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -62,7 +62,7 @@ class AnalysisServerWrapper {
         } else {
           return -1 * xRelevance.compareTo(yRelevance);
         }});
-      return new api.CompleteResponse.fromCompletions(
+      return new api.CompleteResponse(
           response['replacementOffset'], response['replacementLength'],
           results);
     });
@@ -70,9 +70,7 @@ class AnalysisServerWrapper {
 
   Future<api.FixesResponse> getFixes(String src, int offset) async {
     var results = _getFixesImpl(src, offset);
-    return results.then((fixes) {
-      return new api.FixesResponse.fromFixes(fixes.fixes);
-    });
+    return results.then((fixes) => new api.FixesResponse(fixes.fixes));
   }
 
   Future<api.FormatResponse> format(String src, int offset) async {
@@ -85,7 +83,7 @@ class AnalysisServerWrapper {
       for (var edit in edits) {
         editSrc = edit.apply(editSrc);
       }
-      return new api.FormatResponse.fromCode(editSrc, editResult.selectionOffset);
+      return new api.FormatResponse(editSrc, editResult.selectionOffset);
     });
   }
 
@@ -151,7 +149,7 @@ class _Server {
   bool isSetup = false;
   bool isSettingUp = false;
 
-  // TODO(lukechurch): Replace this with a notice baord + dispatcher pattern
+  // TODO(lukechurch): Replace this with a notice board + dispatcher pattern
   /// Streams used to handle syncing data with the server
   Stream<bool> analysisComplete;
   StreamController<bool> _onServerStatus;

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -86,7 +86,7 @@ class Analyzer {
 
       issues.sort();
 
-      return new Future.value(new AnalysisResults.fromIssues(issues));
+      return new Future.value(new AnalysisResults(issues));
     } catch (e, st) {
       return new Future.error(e, st);
     }

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -13,8 +13,7 @@ import 'package:rpc/rpc.dart';
 class AnalysisResults {
   final List<AnalysisIssue> issues;
 
-  AnalysisResults() : this.fromIssues([]);
-  AnalysisResults.fromIssues(this.issues);
+  AnalysisResults(this.issues);
 }
 
 class AnalysisIssue implements Comparable {
@@ -75,8 +74,7 @@ class CompileResponse {
   final String result;
   final String sourceMap;
 
-  CompileResponse() : this.fromResponse("", null);
-  CompileResponse.fromResponse(this.result, [this.sourceMap = null]);
+  CompileResponse(this.result, [this.sourceMap]);
 }
 
 class CounterRequest {
@@ -87,15 +85,13 @@ class CounterRequest {
 class CounterResponse {
   final int count;
 
-  CounterResponse() : this.fromCount(0);
-  CounterResponse.fromCount(this.count);
+  CounterResponse(this.count);
 }
 
 class DocumentResponse {
   final Map<String, String> info;
 
-  DocumentResponse() : this.fromInfo();
-  DocumentResponse.fromInfo([this.info]);
+  DocumentResponse(this.info);
 }
 
 class CompleteResponse {
@@ -107,9 +103,8 @@ class CompleteResponse {
 
   final List<Map<String, String>> completions;
 
-  CompleteResponse() : this.fromCompletions(0, 0, []);
-  CompleteResponse.fromCompletions(this.replacementOffset,
-    this.replacementLength, List<Map> completions) :
+  CompleteResponse(
+      this.replacementOffset, this.replacementLength, List<Map> completions) :
     this.completions = _convert(completions);
 
   /**
@@ -134,8 +129,7 @@ class CompleteResponse {
 class FixesResponse {
   final List<ProblemAndFixes> fixes;
 
-  FixesResponse() : this.fromFixes([]);
-  FixesResponse.fromFixes(List<AnalysisErrorFixes> analysisErrorFixes) :
+  FixesResponse(List<AnalysisErrorFixes> analysisErrorFixes) :
     this.fixes = _convert(analysisErrorFixes);
 
   /**
@@ -227,8 +221,7 @@ class FormatResponse {
       description: 'The (optional) new offset of the cursor; can be `null`.')
   final int offset;
 
-  FormatResponse() : this.fromCode("");
-  FormatResponse.fromCode(this.newString, [this.offset = 0]);
+  FormatResponse(this.newString, [this.offset = 0]);
 }
 
 /**
@@ -276,8 +269,6 @@ class VersionResponse {
       description: 'The dart-services backend version.')
   final String servicesVersion;
 
-  VersionResponse() : sdkVersion = null, runtimeVersion = null,
-      appEngineVersion = null, servicesVersion = null;
-  VersionResponse.from({this.sdkVersion, this.runtimeVersion,
+  VersionResponse({this.sdkVersion, this.runtimeVersion,
     this.appEngineVersion, this.servicesVersion});
 }

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -86,7 +86,7 @@ class CommonServer {
   @ApiMethod(method: 'GET', path: 'counter')
   Future<CounterResponse> counterGet({String name}) {
     return counter.getTotal(name).then((total) {
-      return new CounterResponse.fromCount(total);
+      return new CounterResponse(total);
     });
   }
 
@@ -254,8 +254,8 @@ class CommonServer {
       if (!suppressCache && result != null) {
         _logger.info("CACHE: Cache hit for compile");
         var resultObj = new JsonDecoder().convert(result);
-        return new CompileResponse.fromResponse(resultObj["output"],
-          returnSourceMap ? resultObj["sourceMap"] : null);
+        return new CompileResponse(resultObj["output"],
+            returnSourceMap ? resultObj["sourceMap"] : null);
       } else {
         _logger.info("CACHE: MISS, forced: $suppressCache");
         Stopwatch watch = new Stopwatch()..start();
@@ -279,7 +279,7 @@ class CommonServer {
               "sourceMap" : sourceMap
             });
             await setCache(memCacheKey, cachedResult);
-            return new CompileResponse.fromResponse(out, sourceMap);
+            return new CompileResponse(out, sourceMap);
           } else {
             List problems = _filterCompileProblems(results.problems);
             if (problems.isEmpty) problems = results.problems;
@@ -310,7 +310,7 @@ class CommonServer {
           _logger.info(
             'PERF: Computed dartdoc in ${watch.elapsedMilliseconds}ms.');
           counter.increment("DartDocs");
-          return new DocumentResponse.fromInfo(docInfo);
+          return new DocumentResponse(docInfo);
         }).catchError((e, st) {
           _logger.severe('Error during dartdoc: ${e}\n${st}');
           throw e;
@@ -321,11 +321,11 @@ class CommonServer {
     }
   }
 
-  VersionResponse _version() => new VersionResponse.from(
+  VersionResponse _version() => new VersionResponse(
       sdkVersion: compiler.version,
       runtimeVersion: vmVersion,
       servicesVersion: servicesVersion,
-      appEngineVersion: "1.0");
+      appEngineVersion: container.version);
 
   Future<CompleteResponse> _complete(String source, int offset) async {
     srcRequestRecorder.record("COMPLETE", source, offset);
@@ -348,8 +348,8 @@ class CommonServer {
     AnalysisResults analysisResults = await analyzer.analyze(source);
 
     if (analysisResults.issues.where(
-      (issue) => issue.kind == "error").length > 0) {
-      return new FormatResponse.fromCode(source, offset);
+        (issue) => issue.kind == "error").length > 0) {
+      return new FormatResponse(source, offset);
     }
     return analysisServer.format(source, offset);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,12 +26,12 @@ dependencies:
   compiler_unsupported: 1.10.0
   crypto: '>=0.9.0 <0.10.0'
   librato: '>=0.0.1 <0.1.0'
-  logging: '>=0.9.0 <0.11.0'
+  logging: '>=0.9.0 <0.12.0'
   path: ^1.3.0
   shelf: ^0.6.0
   shelf_cors: ^0.2.0
   shelf_route: ^0.12.0
-  rpc: ^0.4.1
+  rpc: ^0.5.0
   yaml: ^2.0.0
 dev_dependencies:
   _discoveryapis_commons: any


### PR DESCRIPTION
- upgrade `rpc` to 0.5.0
- revert to using ctors with args on response objects
- fix a bug in the `/version` service call, where the appengine version wasn't reported properly

@lukechurch 