### PR TITLE
add additional analysis info to the /analyze service call

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -644,12 +644,12 @@ class AnalysisIssue {
 
   core.int line;
 
-  /** deprecated - see sourcePath */
+  /** deprecated - see `sourceName` */
   core.String location;
 
   core.String message;
 
-  core.String sourcePath;
+  core.String sourceName;
 
 
   AnalysisIssue();
@@ -676,8 +676,8 @@ class AnalysisIssue {
     if (_json.containsKey("message")) {
       message = _json["message"];
     }
-    if (_json.containsKey("sourcePath")) {
-      sourcePath = _json["sourcePath"];
+    if (_json.containsKey("sourceName")) {
+      sourceName = _json["sourceName"];
     }
   }
 
@@ -704,8 +704,8 @@ class AnalysisIssue {
     if (message != null) {
       _json["message"] = message;
     }
-    if (sourcePath != null) {
-      _json["sourcePath"] = sourcePath;
+    if (sourceName != null) {
+      _json["sourceName"] = sourceName;
     }
     return _json;
   }

--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -103,6 +103,47 @@ class DartservicesApi {
   }
 
   /**
+   * Analyze the given Dart source code and return any resulting analysis errors
+   * or warnings.
+   *
+   * [request] - The metadata request object.
+   *
+   * Request parameters:
+   *
+   * Completes with a [AnalysisResults].
+   *
+   * Completes with a [commons.ApiRequestError] if the API endpoint returned an
+   * error.
+   *
+   * If the used [http.Client] completes with an error when making a REST call,
+   * this method  will complete with the same error.
+   */
+  async.Future<AnalysisResults> analyzeMulti(SourcesRequest request) {
+    var _url = null;
+    var _queryParams = new core.Map();
+    var _uploadMedia = null;
+    var _uploadOptions = null;
+    var _downloadOptions = commons.DownloadOptions.Metadata;
+    var _body = null;
+
+    if (request != null) {
+      _body = convert.JSON.encode((request).toJson());
+    }
+
+
+    _url = 'analyzeMulti';
+
+    var _response = _requester.request(_url,
+                                       "POST",
+                                       body: _body,
+                                       queryParams: _queryParams,
+                                       uploadOptions: _uploadOptions,
+                                       uploadMedia: _uploadMedia,
+                                       downloadOptions: _downloadOptions);
+    return _response.then((data) => new AnalysisResults.fromJson(data));
+  }
+
+  /**
    * Compile the given Dart source code and return the resulting JavaScript.
    *
    * [request] - The metadata request object.
@@ -603,9 +644,12 @@ class AnalysisIssue {
 
   core.int line;
 
+  /** deprecated - see sourcePath */
   core.String location;
 
   core.String message;
+
+  core.String sourcePath;
 
 
   AnalysisIssue();
@@ -632,6 +676,9 @@ class AnalysisIssue {
     if (_json.containsKey("message")) {
       message = _json["message"];
     }
+    if (_json.containsKey("sourcePath")) {
+      sourcePath = _json["sourcePath"];
+    }
   }
 
   core.Map toJson() {
@@ -657,6 +704,9 @@ class AnalysisIssue {
     if (message != null) {
       _json["message"] = message;
     }
+    if (sourcePath != null) {
+      _json["sourcePath"] = sourcePath;
+    }
     return _json;
   }
 }
@@ -665,6 +715,12 @@ class AnalysisIssue {
 class AnalysisResults {
   core.List<AnalysisIssue> issues;
 
+  /** The package imports parsed from the source. */
+  core.List<core.String> packageImports;
+
+  /** The resolved imports - e.g. dart:async, dart:io, ... */
+  core.List<core.String> resolvedImports;
+
 
   AnalysisResults();
 
@@ -672,12 +728,24 @@ class AnalysisResults {
     if (_json.containsKey("issues")) {
       issues = _json["issues"].map((value) => new AnalysisIssue.fromJson(value)).toList();
     }
+    if (_json.containsKey("packageImports")) {
+      packageImports = _json["packageImports"];
+    }
+    if (_json.containsKey("resolvedImports")) {
+      resolvedImports = _json["resolvedImports"];
+    }
   }
 
   core.Map toJson() {
     var _json = new core.Map();
     if (issues != null) {
       _json["issues"] = issues.map((value) => (value).toJson()).toList();
+    }
+    if (packageImports != null) {
+      _json["packageImports"] = packageImports;
+    }
+    if (resolvedImports != null) {
+      _json["resolvedImports"] = resolvedImports;
     }
     return _json;
   }
@@ -925,6 +993,36 @@ class FormatResponse {
 }
 
 
+class Location {
+  core.String fullName;
+
+  core.int offset;
+
+
+  Location();
+
+  Location.fromJson(core.Map _json) {
+    if (_json.containsKey("fullName")) {
+      fullName = _json["fullName"];
+    }
+    if (_json.containsKey("offset")) {
+      offset = _json["offset"];
+    }
+  }
+
+  core.Map toJson() {
+    var _json = new core.Map();
+    if (fullName != null) {
+      _json["fullName"] = fullName;
+    }
+    if (offset != null) {
+      _json["offset"] = offset;
+    }
+    return _json;
+  }
+}
+
+
 class ProblemAndFixes {
   core.List<CandidateFix> fixes;
 
@@ -1035,6 +1133,38 @@ class SourceRequest {
     }
     if (source != null) {
       _json["source"] = source;
+    }
+    return _json;
+  }
+}
+
+
+class SourcesRequest {
+  /** An optional location in the source code. */
+  Location location;
+
+  /** Map of names to Sources. */
+  core.Map<core.String, core.String> sources;
+
+
+  SourcesRequest();
+
+  SourcesRequest.fromJson(core.Map _json) {
+    if (_json.containsKey("location")) {
+      location = new Location.fromJson(_json["location"]);
+    }
+    if (_json.containsKey("sources")) {
+      sources = _json["sources"];
+    }
+  }
+
+  core.Map toJson() {
+    var _json = new core.Map();
+    if (location != null) {
+      _json["location"] = (location).toJson();
+    }
+    if (sources != null) {
+      _json["sources"] = sources;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "42dedf5be1217e5f46fa3c199556964c515ca7f5",
+ "etag": "bcdd5cd7a7ae417c9cb60ad19808faa04c5f57d4",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -48,6 +48,20 @@
      "items": {
       "$ref": "AnalysisIssue"
      }
+    },
+    "packageImports": {
+     "type": "array",
+     "description": "The package imports parsed from the source.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "resolvedImports": {
+     "type": "array",
+     "description": "The resolved imports - e.g. dart:async, dart:io, ...",
+     "items": {
+      "type": "string"
+     }
     }
    }
   },
@@ -65,6 +79,9 @@
     "message": {
      "type": "string"
     },
+    "sourcePath": {
+     "type": "string"
+    },
     "hasFixes": {
      "type": "boolean"
     },
@@ -77,7 +94,39 @@
      "format": "int32"
     },
     "location": {
+     "type": "string",
+     "description": "deprecated - see sourcePath"
+    }
+   }
+  },
+  "SourcesRequest": {
+   "id": "SourcesRequest",
+   "type": "object",
+   "properties": {
+    "sources": {
+     "type": "object",
+     "description": "Map of names to Sources.",
+     "required": true,
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "location": {
+     "$ref": "Location",
+     "description": "An optional location in the source code."
+    }
+   }
+  },
+  "Location": {
+   "id": "Location",
+   "type": "object",
+   "properties": {
+    "fullName": {
      "type": "string"
+    },
+    "offset": {
+     "type": "integer",
+     "format": "int32"
     }
    }
   },
@@ -281,6 +330,20 @@
    "parameterOrder": [],
    "request": {
     "$ref": "SourceRequest"
+   },
+   "response": {
+    "$ref": "AnalysisResults"
+   }
+  },
+  "analyzeMulti": {
+   "id": "CommonServer.analyzeMulti",
+   "path": "analyzeMulti",
+   "httpMethod": "POST",
+   "description": "Analyze the given Dart source code and return any resulting analysis errors or warnings.",
+   "parameters": {},
+   "parameterOrder": [],
+   "request": {
+    "$ref": "SourcesRequest"
    },
    "response": {
     "$ref": "AnalysisResults"

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "bcdd5cd7a7ae417c9cb60ad19808faa04c5f57d4",
+ "etag": "fd1ff4494fc57b70e09fa940ed802290a55d9668",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -79,7 +79,7 @@
     "message": {
      "type": "string"
     },
-    "sourcePath": {
+    "sourceName": {
      "type": "string"
     },
     "hasFixes": {
@@ -95,7 +95,7 @@
     },
     "location": {
      "type": "string",
-     "description": "deprecated - see sourcePath"
+     "description": "deprecated - see `sourceName`"
     }
    }
   },

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -104,7 +104,7 @@ class Analyzer {
             error.severityName, error.line, error.message,
             location: error.location,
             charStart: error.offset, charLength: error.length,
-            sourcePath: error.error.source.fullName,
+            sourceName: error.error.source.fullName,
             hasFixes: error.probablyHasFix);
       }).toList();
       issues.sort();

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -94,23 +94,29 @@ class Analyzer {
         errorInfos.add(_context.getErrors(s));
       });
 
-      List<_Error> errors = errorInfos
-        .expand((AnalysisErrorInfo info) {
+      List<_Error> errors = errorInfos.expand((AnalysisErrorInfo info) {
         return info.errors.map((error) => new _Error(error, info.lineInfo));
-      })
-      .where((_Error error) => error.errorType != ErrorType.TODO)
-      .toList();
+      }).where((_Error error) => error.errorType != ErrorType.TODO).toList();
 
+      // Calculate the issues.
       List<AnalysisIssue> issues = errors.map((_Error error) {
         return new AnalysisIssue.fromIssue(
             error.severityName, error.line, error.message,
             location: error.location,
             charStart: error.offset, charLength: error.length,
-            fullName: error.error.source.fullName,
+            sourcePath: error.error.source.fullName,
             hasFixes: error.probablyHasFix);
       }).toList();
-
       issues.sort();
+
+      // Calculate the imports.
+      Set<String> packageImports = new Set();
+      for (String source in sources.values) {
+        // TODO: Use the `pub` object for this in the future.
+        packageImports.addAll(
+            filterSafePackagesFromImports(getAllUnsafeImportsFor(source)));
+      }
+      List<String> resolvedImports = _calculateImports(_context, sourcesList);
 
       // Delete the files
       changeSet = new ChangeSet();
@@ -118,13 +124,13 @@ class Analyzer {
       _resolver.clear();
       _context.applyChanges(changeSet);
 
-      return new Future.value(new AnalysisResults(issues));
+      return new Future.value(new AnalysisResults(
+          issues, packageImports.toList(), resolvedImports));
     } catch (e, st) {
       _reset();
       return new Future.error(e, st);
     }
   }
-
 
   Future<Map<String, String>> dartdoc(String source, int offset) {
     try {
@@ -238,6 +244,24 @@ class Analyzer {
     }
 
     return null;
+  }
+
+  /// Calculate the resolved imports for the given set of sources.
+  List<String> _calculateImports(AnalysisContext context, List<Source> sources) {
+    Set<String> imports = new Set();
+
+    for (Source source in sources) {
+      LibraryElement element = context.getLibraryElement(source);
+
+      if (element != null) {
+        element.imports.forEach((ImportElement import) {
+          // The dart:core implicit import has a null uri.
+          if (import.uri != null) imports.add(import.uri);
+        });
+      }
+    }
+
+    return imports.toList();
   }
 
   // TODO(lukechurch): Determine whether we can change this in the Analyzer.

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -26,7 +26,7 @@ class AnalysisIssue implements Comparable {
   final String kind;
   final int line;
   final String message;
-  final String sourcePath;
+  final String sourceName;
 
   final bool hasFixes;
 
@@ -34,13 +34,13 @@ class AnalysisIssue implements Comparable {
   final int charLength;
   // TODO: Once all clients have started using fullName, we should remove the
   // location field.
-  @Deprecated('use sourcePath instead')
-  @ApiProperty(description: 'deprecated - see `sourcePath`')
+  @Deprecated('use sourceName instead')
+  @ApiProperty(description: 'deprecated - see `sourceName`')
   final String location;
 
   AnalysisIssue.fromIssue(this.kind, this.line, this.message,
       {this.charStart, this.charLength, this.location,
-      this.sourcePath, this.hasFixes: false});
+      this.sourceName, this.hasFixes: false});
 
   Map toMap() {
     Map m = {'kind': kind, 'line': line, 'message': message};

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -13,14 +13,20 @@ import 'package:rpc/rpc.dart';
 class AnalysisResults {
   final List<AnalysisIssue> issues;
 
-  AnalysisResults(this.issues);
+  @ApiProperty(description: 'The package imports parsed from the source.')
+  final List<String> packageImports;
+
+  @ApiProperty(description: 'The resolved imports - e.g. dart:async, dart:io, ...')
+  final List<String> resolvedImports;
+
+  AnalysisResults(this.issues, this.packageImports, this.resolvedImports);
 }
 
 class AnalysisIssue implements Comparable {
   final String kind;
   final int line;
   final String message;
-  final String fullName;
+  final String sourcePath;
 
   final bool hasFixes;
 
@@ -28,12 +34,13 @@ class AnalysisIssue implements Comparable {
   final int charLength;
   // TODO: Once all clients have started using fullName, we should remove the
   // location field.
+  @Deprecated('use sourcePath instead')
+  @ApiProperty(description: 'deprecated - see `sourcePath`')
   final String location;
 
-  AnalysisIssue() : this.fromIssue("", 0, "");
   AnalysisIssue.fromIssue(this.kind, this.line, this.message,
       {this.charStart, this.charLength, this.location,
-      this.fullName, this.hasFixes: false});
+      this.sourcePath, this.hasFixes: false});
 
   Map toMap() {
     Map m = {'kind': kind, 'line': line, 'message': message};

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -21,7 +21,6 @@ void main() {
 }
 """;
 
-
 final String sampleCodeMultiFoo = """
 import 'bar.dart';
 

--- a/test/analyzer_test.dart
+++ b/test/analyzer_test.dart
@@ -174,7 +174,7 @@ void main() {
 
       return analyzer.analyzeMulti(sourceMap).then((AnalysisResults results) {
         expect(results.issues, isNotEmpty);
-        expect(results.issues[0].sourcePath, "main.dart");
+        expect(results.issues[0].sourceName, "main.dart");
       });
     });
 
@@ -184,7 +184,7 @@ void main() {
 
       return analyzer.analyzeMulti(sourceMap).then((AnalysisResults results) {
         expect(results.issues, isNotEmpty);
-        expect(results.issues[0].sourcePath, "foo.dart");
+        expect(results.issues[0].sourceName, "foo.dart");
       });
     });
 

--- a/test/analyzer_test.dart
+++ b/test/analyzer_test.dart
@@ -39,6 +39,28 @@ void defineTests() {
       });
     });
 
+    test('import parsing', () {
+      final String sample = '''
+import 'dart:async';
+import 'dart:io';
+import 'package:bar/bar.dart';
+import 'package:baz/baz.dart';
+
+void main() {
+  print('hello');
+}
+''';
+
+      return analyzer.analyze(sample).then((AnalysisResults results) {
+        expect(results.packageImports.length, 2);
+        expect(results.packageImports[0], 'bar');
+        expect(results.packageImports[1], 'baz');
+        expect(results.resolvedImports.length, 2);
+        expect(results.resolvedImports[0], 'dart:async');
+        expect(results.resolvedImports[1], 'dart:io');
+      });
+    });
+
     test('errors', () {
       return analyzer.analyze(sampleCodeError).then((AnalysisResults results) {
         expect(results.issues.length, 1);
@@ -100,7 +122,7 @@ void main() {
       });
     });
 
-    test('future pretified', () {
+    test('future prettified', () {
       final String source = '''
 import 'dart:async';
 
@@ -152,7 +174,7 @@ void main() {
 
       return analyzer.analyzeMulti(sourceMap).then((AnalysisResults results) {
         expect(results.issues, isNotEmpty);
-        expect(results.issues[0].fullName, "main.dart");
+        expect(results.issues[0].sourcePath, "main.dart");
       });
     });
 
@@ -162,7 +184,7 @@ void main() {
 
       return analyzer.analyzeMulti(sourceMap).then((AnalysisResults results) {
         expect(results.issues, isNotEmpty);
-        expect(results.issues[0].fullName, "foo.dart");
+        expect(results.issues[0].sourcePath, "foo.dart");
       });
     });
 

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -89,7 +89,11 @@ void defineTests() {
       var response = await _sendPostRequest('dartservices/v1/analyze', json);
       expect(response.status, 200);
       var data = await response.body.first;
-      expect(JSON.decode(UTF8.decode(data)), { 'issues': [] });
+      expect(JSON.decode(UTF8.decode(data)), {
+        'issues': [],
+        'packageImports': [],
+        'resolvedImports': []
+      });
     });
 
     test('analyze errors', () async {
@@ -104,14 +108,17 @@ void defineTests() {
           {
             "kind": "error",
             "line": 2,
-            "fullName": "main.dart",
+            "sourcePath": "main.dart",
             "message": "Expected to find \';\'",
             "hasFixes": true,
             "charStart": 29,
             "charLength": 1,
             "location": "main.dart"
           }
-      ]};
+        ],
+        'packageImports': [],
+        'resolvedImports': []
+      };
       expect(JSON.decode(UTF8.decode(data)), expectedJson);
     });
 

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -108,7 +108,7 @@ void defineTests() {
           {
             "kind": "error",
             "line": 2,
-            "sourcePath": "main.dart",
+            "sourceName": "main.dart",
             "message": "Expected to find \';\'",
             "hasFixes": true,
             "charStart": 29,

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -26,7 +26,7 @@ void defineTests() {
         expect(result.getSourceMap(), isEmpty);
       });
     });
-    
+
     test('sourcemap', () {
       return compiler.compile(sampleCode, returnSourceMap: true).then(
           (CompilationResults result) {
@@ -35,7 +35,7 @@ void defineTests() {
         expect(result.getSourceMap(), isNotEmpty);
       });
     });
-    
+
     test('version', () {
       return compiler.compile(sampleCode, returnSourceMap: true).then(
           (CompilationResults result) {
@@ -44,7 +44,6 @@ void defineTests() {
         expect(result.getSourceMap(), isNotEmpty);
       });
     });
-
 
     // TODO: How to get different source when compiling with --checked?
 //    test('checked', () {


### PR DESCRIPTION
- fix #162, add import info to the `/analyze` service call (to make the client aware of things like a transitive `dart:io` import)
- re-gen the api library (capture the `/analyzeMulti` call and the sidecar analysis info change)
- rename `fullName` to `sourcePath` for clarity

@lukechurch 