### PR TITLE
Support multiple files for completion, fixes

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -305,6 +305,46 @@ class DartservicesApi {
   }
 
   /**
+   * Get the valid code completion results for the given offset.
+   *
+   * [request] - The metadata request object.
+   *
+   * Request parameters:
+   *
+   * Completes with a [CompleteResponse].
+   *
+   * Completes with a [commons.ApiRequestError] if the API endpoint returned an
+   * error.
+   *
+   * If the used [http.Client] completes with an error when making a REST call,
+   * this method  will complete with the same error.
+   */
+  async.Future<CompleteResponse> completeMulti(SourcesRequest request) {
+    var _url = null;
+    var _queryParams = new core.Map();
+    var _uploadMedia = null;
+    var _uploadOptions = null;
+    var _downloadOptions = commons.DownloadOptions.Metadata;
+    var _body = null;
+
+    if (request != null) {
+      _body = convert.JSON.encode((request).toJson());
+    }
+
+
+    _url = 'completeMulti';
+
+    var _response = _requester.request(_url,
+                                       "POST",
+                                       body: _body,
+                                       queryParams: _queryParams,
+                                       uploadOptions: _uploadOptions,
+                                       uploadMedia: _uploadMedia,
+                                       downloadOptions: _downloadOptions);
+    return _response.then((data) => new CompleteResponse.fromJson(data));
+  }
+
+  /**
    * Request parameters:
    *
    * [name] - Query parameter: 'name'.
@@ -501,6 +541,46 @@ class DartservicesApi {
 
     var _response = _requester.request(_url,
                                        "GET",
+                                       body: _body,
+                                       queryParams: _queryParams,
+                                       uploadOptions: _uploadOptions,
+                                       uploadMedia: _uploadMedia,
+                                       downloadOptions: _downloadOptions);
+    return _response.then((data) => new FixesResponse.fromJson(data));
+  }
+
+  /**
+   * Get any quick fixes for the given source code location.
+   *
+   * [request] - The metadata request object.
+   *
+   * Request parameters:
+   *
+   * Completes with a [FixesResponse].
+   *
+   * Completes with a [commons.ApiRequestError] if the API endpoint returned an
+   * error.
+   *
+   * If the used [http.Client] completes with an error when making a REST call,
+   * this method  will complete with the same error.
+   */
+  async.Future<FixesResponse> fixesMulti(SourcesRequest request) {
+    var _url = null;
+    var _queryParams = new core.Map();
+    var _uploadMedia = null;
+    var _uploadOptions = null;
+    var _downloadOptions = commons.DownloadOptions.Metadata;
+    var _body = null;
+
+    if (request != null) {
+      _body = convert.JSON.encode((request).toJson());
+    }
+
+
+    _url = 'fixesMulti';
+
+    var _response = _requester.request(_url,
+                                       "POST",
                                        body: _body,
                                        queryParams: _queryParams,
                                        uploadOptions: _uploadOptions,
@@ -994,29 +1074,29 @@ class FormatResponse {
 
 
 class Location {
-  core.String fullName;
-
   core.int offset;
+
+  core.String sourceName;
 
 
   Location();
 
   Location.fromJson(core.Map _json) {
-    if (_json.containsKey("fullName")) {
-      fullName = _json["fullName"];
-    }
     if (_json.containsKey("offset")) {
       offset = _json["offset"];
+    }
+    if (_json.containsKey("sourceName")) {
+      sourceName = _json["sourceName"];
     }
   }
 
   core.Map toJson() {
     var _json = new core.Map();
-    if (fullName != null) {
-      _json["fullName"] = fullName;
-    }
     if (offset != null) {
       _json["offset"] = offset;
+    }
+    if (sourceName != null) {
+      _json["sourceName"] = sourceName;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "fd1ff4494fc57b70e09fa940ed802290a55d9668",
+ "etag": "7364ddf579795afffb0c3642b20ccfaad8f148c6",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -121,7 +121,7 @@
    "id": "Location",
    "type": "object",
    "properties": {
-    "fullName": {
+    "sourceName": {
      "type": "string"
     },
     "offset": {
@@ -411,6 +411,20 @@
     "$ref": "CompleteResponse"
    }
   },
+  "completeMulti": {
+   "id": "CommonServer.completeMulti",
+   "path": "completeMulti",
+   "httpMethod": "POST",
+   "description": "Get the valid code completion results for the given offset.",
+   "parameters": {},
+   "parameterOrder": [],
+   "request": {
+    "$ref": "SourcesRequest"
+   },
+   "response": {
+    "$ref": "CompleteResponse"
+   }
+  },
   "completeGet": {
    "id": "CommonServer.completeGet",
    "path": "complete",
@@ -443,6 +457,20 @@
    "parameterOrder": [],
    "request": {
     "$ref": "SourceRequest"
+   },
+   "response": {
+    "$ref": "FixesResponse"
+   }
+  },
+  "fixesMulti": {
+   "id": "CommonServer.fixesMulti",
+   "path": "fixesMulti",
+   "httpMethod": "POST",
+   "description": "Get any quick fixes for the given source code location.",
+   "parameters": {},
+   "parameterOrder": [],
+   "request": {
+    "$ref": "SourcesRequest"
    },
    "response": {
     "$ref": "FixesResponse"

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -51,7 +51,7 @@ class AnalysisServerWrapper {
   Future<api.CompleteResponse> complete(String src, int offset) async =>
     completeMulti({"main.dart" : src},
       new api.Location()
-        ..fullName = "main.dart"
+        ..sourceName = "main.dart"
         ..offset = offset);
 
   Future<api.CompleteResponse> completeMulti(
@@ -59,7 +59,7 @@ class AnalysisServerWrapper {
     api.Location location) async {
 
     Future<Map> results = _completeImpl(
-      sources, location.fullName, location.offset);
+      sources, location.sourceName, location.offset);
 
     // Post process the result from Analysis Server.
     return results.then((Map response) {
@@ -87,12 +87,12 @@ class AnalysisServerWrapper {
     getFixesMulti(
       {"main.dart" : src},
       new api.Location()
-        ..fullName = "main.dart"
+        ..sourceName = "main.dart"
         ..offset = offset);
 
   Future<api.FixesResponse> getFixesMulti(
       Map<String, String> sources, api.Location location) async {
-    var results = _getFixesImpl(sources, location.fullName, location.offset);
+    var results = _getFixesImpl(sources, location.sourceName, location.offset);
     return results.then((fixes) => new api.FixesResponse(fixes.fixes));
   }
 

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -168,9 +168,7 @@ class AnalysisServerWrapper {
 
   /// Warm up the analysis server to be ready for use.
   Future warmup([bool useHtml = false]) =>
-      _completeImpl(
-          {mainPath : useHtml ? _WARMUP_SRC_HTML : _WARMUP_SRC},
-          mainPath, 10);
+    complete(useHtml ? _WARMUP_SRC_HTML : _WARMUP_SRC, 10);
 }
 
 /**

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -223,8 +223,7 @@ class _Server {
     _logger.fine("Server Set Subscriptions completed");
 
     await sendAddOverlays({
-        "${sourceDirectory.path}${io.Platform.pathSeparator}main.dart" :
-        _WARMUP_SRC});
+        mainPath : _WARMUP_SRC});
     sendAnalysisSetAnalysisRoots([sourceDirectory.path], []);
     isSettingUp = false;
     isSetup = true;

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -119,7 +119,7 @@ class AnalysisServerWrapper {
   /// Internal implementation of the completion mechanism.
   Future<Map> _completeImpl(Map<String, String> sources,
                             String sourceName, int offset) async {
-    sources = _rewriteOverlayNamesToPaths(sources);
+    sources = _getOverlayMapWithPaths(sources);
     String path = _getPathFromName(sourceName);
     await serverConnection._ensureSetup();
     await serverConnection.loadSources(sources);
@@ -135,7 +135,7 @@ class AnalysisServerWrapper {
 
   Future<EditGetFixesResult> _getFixesImpl(
       Map<String, String> sources, String sourceName, int offset) async {
-    sources = _rewriteOverlayNamesToPaths(sources);
+    sources = _getOverlayMapWithPaths(sources);
     String path = _getPathFromName(sourceName);
 
     await serverConnection._ensureSetup();
@@ -155,7 +155,7 @@ class AnalysisServerWrapper {
     return formatResult;
   }
 
-  Map<String, String> _rewriteOverlayNamesToPaths(Map<String, String> overlay) {
+  Map<String, String> _getOverlayMapWithPaths(Map<String, String> overlay) {
     var newOverlay = {};
     overlay.forEach((k,v) => newOverlay.putIfAbsent(
       _getPathFromName(k), () => v)

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -70,7 +70,7 @@ class SourcesRequest {
 }
 
 class Location {
-  String fullName;
+  String sourceName;
   int offset;
 }
 

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -148,7 +148,7 @@ class CommonServer {
     }
 
     return _completeMulti(
-        request.sources, request.location.fullName, request.location.offset);
+        request.sources, request.location.sourceName, request.location.offset);
   }
 
 
@@ -181,7 +181,7 @@ class CommonServer {
       path: 'fixesMulti',
       description: 'Get any quick fixes for the given source code location.')
   Future<FixesResponse> fixesMulti(SourcesRequest request) {
-    if (request.location.fullName == null) {
+    if (request.location.sourceName == null) {
       throw new BadRequestError('Missing parameter: \'fullName\'');
     }
     if (request.location.offset == null) {
@@ -189,7 +189,7 @@ class CommonServer {
     }
 
     return _fixesMulti(
-        request.sources, request.location.fullName, request.location.offset);
+        request.sources, request.location.sourceName, request.location.offset);
   }
 
   @ApiMethod(method: 'GET', path: 'fixes')
@@ -405,7 +405,7 @@ class CommonServer {
       counter.increment("Completions");
       var response = await analysisServer.completeMulti(sources,
         new Location()
-          ..fullName = name
+          ..sourceName = name
           ..offset = offset);
       _logger.info('PERF: Computed completions in ${watch.elapsedMilliseconds}ms.');
       return response;
@@ -437,7 +437,7 @@ class CommonServer {
     counter.increment("Fixes");
     var response = await analysisServer.getFixesMulti(sources,
       new Location()
-        ..fullName = name
+        ..sourceName = name
         ..offset = offset);
     _logger.info('PERF: Computed fixes in ${watch.elapsedMilliseconds}ms.');
     return response;

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -387,11 +387,11 @@ class CommonServer {
   }
 
   Future<CompleteResponse> _completeMulti(Map<String, String> sources,
-    String name, int offset) async {
+    String sourceName, int offset) async {
       if (sources == null) {
         throw new BadRequestError('Missing parameter: \'source\'');
       }
-      if (name == null) {
+      if (sourceName == null) {
         throw new BadRequestError('Missing parameter: \'name\'');
       }
       if (offset == null) {
@@ -405,7 +405,7 @@ class CommonServer {
       counter.increment("Completions");
       var response = await analysisServer.completeMulti(sources,
         new Location()
-          ..sourceName = name
+          ..sourceName = sourceName
           ..offset = offset);
       _logger.info('PERF: Computed completions in ${watch.elapsedMilliseconds}ms.');
       return response;
@@ -423,7 +423,7 @@ class CommonServer {
   }
 
   Future<FixesResponse> _fixesMulti(Map<String, String> sources,
-    String name, int offset) async {
+    String sourceName, int offset) async {
     if (sources == null) {
       throw new BadRequestError('Missing parameter: \'sources\'');
     }
@@ -437,7 +437,7 @@ class CommonServer {
     counter.increment("Fixes");
     var response = await analysisServer.getFixesMulti(sources,
       new Location()
-        ..sourceName = name
+        ..sourceName = sourceName
         ..offset = offset);
     _logger.info('PERF: Computed fixes in ${watch.elapsedMilliseconds}ms.');
     return response;

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -112,6 +112,9 @@ Usage: slow_test path_to_test_collection
  * Init the tools, and warm them up
  */
 setupTools(String sdkPath) async {
+  print ("Executing setupTools");
+  if (analysisServer != null) await analysisServer.kill();
+
   container = new MockContainer();
   cache = new MockCache();
   recorder = new MockRequestRecorder();


### PR DESCRIPTION
@devoncarew PTAL This adds support for multiple files in the EPs that use the Analysis Server.

It needs two follow on PRs:

1. Add unit tests for multiple files. The code paths are tested with EPs for single files but needs extending.
2. Adjust the sendOverlay implementation so that it sends the overlays in one Analysis Server message rather than 1 per file.

I'll file issues for these, neither affects the correctness of the functioning of this implementation