### PR TITLE
Remove additional CORS settings

### DIFF
--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -64,8 +64,6 @@ class GaeServer {
   Future start() => ae.runAppEngine(requestHandler);
 
   void requestHandler(io.HttpRequest request) {
-    request.response.headers.add('Access-Control-Allow-Origin', '*');
-    request.response.headers.add('Access-Control-Allow-Credentials', 'true');
     request.response.headers.add('Access-Control-Allow-Methods',
         'POST, OPTIONS');
     request.response.headers.add('Access-Control-Allow-Headers',


### PR DESCRIPTION
@devoncarew TBR These values are now being set in one of the libraries, which was resulting in them being set twice, and hence causing requests to fail.

With this change the dev deploy of the UI talks successfully with a dev deploy of the services library. Doing more manual testing now.