### PR TITLE
Move to v1.10.1

### DIFF
--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -235,14 +235,10 @@ class _Server {
   Future loadSources(Map<String, String> sources) async {
     await sendAddOverlays(sources);
     await sendPrioritySetSources(sources.keys.toList());
-    sources.keys.forEach((path) =>
-      new io.File(path).writeAsStringSync("", flush: true));
   }
 
   Future unloadSources(List<String> paths) async {
     await sendRemoveOverlays(paths);
-    paths.forEach((path) =>
-      new io.File(path).deleteSync());
   }
 
   /**

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -149,7 +149,7 @@ class Analyzer {
   }
 
   Map<String, String> _computeDartdocInfo(CompilationUnit unit, int offset) {
-    AstNode node = new NodeLocator.con1(offset).searchWithin(unit);
+    AstNode node = new NodeLocator(offset).searchWithin(unit);
 
     if (node.parent is TypeName &&
         node.parent.parent is ConstructorName &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,15 +9,15 @@ dependencies:
   analysis_server:
     git:
       url: git://github.com/lukechurch/dart-analysis-server-temp-working.git
-      ref: v1_10_0
+      ref: v1_10_1
   analyzer:
     git:
       url: git://github.com/lukechurch/dart-analyzer-temp-working.git
-      ref: v1_10_0
+      ref: v1_10_1
   dart_style:
     git:
       url: git://github.com/lukechurch/dart_style.git
-      ref: v1_10_0
+      ref: v1_10_1
   appengine: '>=0.3.0 <0.4.0'
   archive: '>=1.0.19 <1.1.0'
   args: '>=0.12.0 <0.14.0'


### PR DESCRIPTION
This fixes a reliability + minor performance issue with the v1.10.1 + multiple files version associated with this: https://github.com/dart-lang/dart-services/issues/204 restoring everything being in memory-only again.

It also takes the newer code from the SDK and fixes the use of a depreciated API

FYI @devoncarew 