### PR TITLE
Add missing perform analysis task

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -123,6 +123,7 @@ class Analyzer {
       sourcesList.forEach((s) => changeSet.removedSource(s));
       _resolver.clear();
       _context.applyChanges(changeSet);
+      _context.performAnalysisTask();
 
       return new Future.value(new AnalysisResults(
           issues, packageImports.toList(), resolvedImports));


### PR DESCRIPTION
TBR @devoncarew 

This is needed to fix a slow memory leak that is causing a progressive decay in server performance over a number of days.

I've done a 250K test, and it improves performance by decreasing the stress on the GC. With this change memory footprint for the Analyzer is stable at 300Mb. Without it, it grows to system exhaustion.