### PR TITLE
add more version info

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -1251,6 +1251,8 @@ class VersionResponse {
    * semver string.
    */
   core.String sdkVersion;
+  /** The full Dart SDK version that DartServices is compatible with. */
+  core.String sdkVersionFull;
   /** The dart-services backend version. */
   core.String servicesVersion;
 
@@ -1265,6 +1267,9 @@ class VersionResponse {
     }
     if (_json.containsKey("sdkVersion")) {
       sdkVersion = _json["sdkVersion"];
+    }
+    if (_json.containsKey("sdkVersionFull")) {
+      sdkVersionFull = _json["sdkVersionFull"];
     }
     if (_json.containsKey("servicesVersion")) {
       servicesVersion = _json["servicesVersion"];
@@ -1281,6 +1286,9 @@ class VersionResponse {
     }
     if (sdkVersion != null) {
       _json["sdkVersion"] = sdkVersion;
+    }
+    if (sdkVersionFull != null) {
+      _json["sdkVersionFull"] = sdkVersionFull;
     }
     if (servicesVersion != null) {
       _json["servicesVersion"] = servicesVersion;

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "0aa77a088adf1d0f493048752b9dabfab6f8bf54",
+ "etag": "ffc1ef3d5358d3edc9bdb221ad65d3989f5ffd3f",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -296,6 +296,10 @@
     "sdkVersion": {
      "type": "string",
      "description": "The Dart SDK version that DartServices is compatible with. This will be a semver string."
+    },
+    "sdkVersionFull": {
+     "type": "string",
+     "description": "The full Dart SDK version that DartServices is compatible with."
     },
     "runtimeVersion": {
      "type": "string",

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -286,6 +286,10 @@ class VersionResponse {
   final String sdkVersion;
 
   @ApiProperty(
+      description: 'The full Dart SDK version that DartServices is compatible with.')
+  final String sdkVersionFull;
+
+  @ApiProperty(
       description: 'The Dart SDK version that the server is running on. This '
         'will start with a semver string, and have a space and other build '
         'details appended.')
@@ -299,6 +303,6 @@ class VersionResponse {
       description: 'The dart-services backend version.')
   final String servicesVersion;
 
-  VersionResponse({this.sdkVersion, this.runtimeVersion,
+  VersionResponse({this.sdkVersion, this.sdkVersionFull, this.runtimeVersion,
     this.appEngineVersion, this.servicesVersion});
 }

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -122,7 +122,7 @@ class CommonServer {
   Future<SummaryText> summarize(SourcesRequest request) {
     return _summarize(request.sources['dart'], request.sources['css'], request.sources['html']);
   }
-  
+
   @ApiMethod(method: 'GET', path: 'analyze')
   Future<AnalysisResults> analyzeGet({String source}) {
     return _analyze(source);
@@ -263,7 +263,7 @@ class CommonServer {
     }
     return _analyzeMulti({"main.dart" : source});
   }
-  
+
   Future<SummaryText> _summarize(String dart, String html, String css) async {
     if (dart == null || html == null || css == null) {
       throw new BadRequestError('Missing core source parameter.');
@@ -400,6 +400,7 @@ class CommonServer {
 
   VersionResponse _version() => new VersionResponse(
       sdkVersion: compiler.version,
+      sdkVersionFull: compiler.versionFull,
       runtimeVersion: vmVersion,
       servicesVersion: servicesVersion,
       appEngineVersion: container.version);

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -36,6 +36,8 @@ class Compiler {
   /// The version of the SDK this copy of dart2js is based on.
   String get version => compilerVersion.version;
 
+  String get versionFull => compilerVersion.versionLong;
+
   Future warmup([bool useHtml = false]) =>
       compile(useHtml ? sampleCodeWeb : sampleCode);
 


### PR DESCRIPTION
Return the full version of the dartpad backend (as well as the version summary we currently have). This will let the frontend display `1.12.0` _and_ the additionally detail of `1.12.0+2`, which can be useful when diagnosing some issues.