### PR TITLE
1.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM google/dart-runtime:1.12.0-dev.1.0
+FROM google/dart-runtime:1.12.0

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-version: v112rc
+version: v-1-12-0
 runtime: custom
 vm: true
 api_version: 1
@@ -8,7 +8,7 @@ resources:
   memory_gb: 3
 
 automatic_scaling:
-  min_num_instances: 3
+  min_num_instances: 6
   max_num_instances: 12
   cool_down_period_sec: 60
   cpu_utilization:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   args: '>=0.12.0 <0.14.0'
   cli_util: ^0.0.1
   # `compiler_unsupported` needs to be pegged to a specific version.
-  compiler_unsupported: '1.12.0-dev.5.2'
+  compiler_unsupported: '1.12.0'
   crypto: '>=0.9.0 <0.10.0'
   librato: '>=0.0.1 <0.1.0'
   logging: '>=0.9.0 <0.12.0'


### PR DESCRIPTION
Rev the compiler package to the latest stable sdk (`1.12.0`).

@lukechurch 