### PR TITLE
fix regressions; upgrade to 1.13.1

### DIFF
--- a/.atom/launches/services.yaml
+++ b/.atom/launches/services.yaml
@@ -1,0 +1,8 @@
+# Cli launch configuration for bin/services.dart.
+type: cli
+path: bin/services.dart
+
+cli:
+  args: 
+  checked: true
+  debug: true

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -6,13 +6,12 @@ library services.bench;
 
 import 'dart:async';
 
+import 'package:grinder/grinder.dart' as grinder;
 import 'package:services/src/analysis_server.dart';
 import 'package:services/src/analyzer.dart';
 import 'package:services/src/bench.dart';
 import 'package:services/src/common.dart';
 import 'package:services/src/compiler.dart';
-
-import 'package:grinder/grinder.dart' as grinder;
 
 final String sdkPath = grinder.getSdkDir().path;
 

--- a/bin/server.dart
+++ b/bin/server.dart
@@ -4,6 +4,8 @@
 
 // To meet GAE needs this file must be called 'server.dart'.
 
+library appengine.services.bin;
+
 import 'package:services/services_gae.dart' as server;
 
 void main(List<String> args) => server.main(args);

--- a/example/apitest.dart
+++ b/example/apitest.dart
@@ -5,10 +5,12 @@
 library services_server.apitest;
 
 import 'dart:html';
+
+import 'package:codemirror/codemirror.dart';
+
 import '../doc/generated/_dartpadsupportservices.dart' as support;
 import '../doc/generated/dartservices.dart' as services;
 import 'services_utils.dart' as utils;
-import 'package:codemirror/codemirror.dart';
 
 utils.SanitizingBrowserClient client;
 services.DartservicesApi servicesApi;

--- a/example/index.dart
+++ b/example/index.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import "dart:html";
 import "dart:convert";
+import "dart:html";
 
 main() {
   querySelector('#sendButton').onClick.listen((e) {

--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -17,7 +17,6 @@ import 'package:rpc/rpc.dart' as rpc;
 
 import 'src/common_server.dart';
 import 'src/dartpad_support_server.dart';
-
 import 'src/sharded_counter.dart' as counter;
 
 const String _API = '/api';
@@ -46,7 +45,7 @@ class GaeServer {
   rpc.ApiServer apiServer;
   CommonServer commonServer;
   FileRelayServer fileRelayServer;
-  
+
   GaeServer(this.sdkPath) {
     hierarchicalLoggingEnabled = true;
     _logger.level = Level.ALL;
@@ -60,9 +59,9 @@ class GaeServer {
         new GaeSourceRequestRecorder(),
         new GaeCounter());
     // Enabled pretty printing of returned json for debuggability.
-    apiServer =
-        new rpc.ApiServer(apiPrefix: _API, prettyPrint: true)..addApi(commonServer)
-        ..addApi(fileRelayServer);
+    apiServer = new rpc.ApiServer(apiPrefix: _API, prettyPrint: true)
+      ..addApi(commonServer)
+      ..addApi(fileRelayServer);
   }
 
   Future start() => ae.runAppEngine(requestHandler);
@@ -83,8 +82,7 @@ class GaeServer {
       } else {
         statusCode = io.HttpStatus.BAD_REQUEST;
       }
-      request.response..statusCode = statusCode
-                      ..close();
+      request.response..statusCode = statusCode..close();
       return;
     }
 
@@ -97,20 +95,20 @@ class GaeServer {
       // the _parseRequest method to determine content-type and dispatch to e.g.
       // a plain text handler if we want to support that.
       var apiRequest = new rpc.HttpApiRequest.fromHttpRequest(request);
-      apiServer.handleHttpApiRequest(apiRequest)
-        .then((rpc.HttpApiResponse apiResponse) {
-          return rpc.sendApiResponse(apiResponse, request.response);
+      apiServer.handleHttpApiRequest(apiRequest).then((rpc.HttpApiResponse apiResponse) {
+        return rpc.sendApiResponse(apiResponse, request.response);
       }).catchError((e) {
-          // This should only happen in the case where there is a bug in the
-          // rpc package. Otherwise it always returns an HttpApiResponse.
-          _logger.warning('Failed with error: $e when trying to call'
-            'method at \'${request.uri.path}\'.');
-          request.response..statusCode = io.HttpStatus.INTERNAL_SERVER_ERROR
-                        ..close();
-          });
+        // This should only happen in the case where there is a bug in the rpc
+        // package. Otherwise it always returns an HttpApiResponse.
+        _logger.warning(
+          'Failed with error: $e when trying to call'
+          'method at \'${request.uri.path}\'.');
+        request.response..statusCode = io.HttpStatus.INTERNAL_SERVER_ERROR
+            ..close();
+      });
     } else {
       request.response..statusCode = io.HttpStatus.INTERNAL_SERVER_ERROR
-                       ..close();
+          ..close();
     }
   }
 }
@@ -151,7 +149,7 @@ class GaeSourceRequestRecorder implements SourceRequestRecorder {
         ms, verb, source, offset);
 
     return new Future.sync(() => db.dbService.commit(inserts: [record]))
-      .catchError((error, stackTrace) {
+        .catchError((error, stackTrace) {
       _logger.fine(
           'Soft-ERR SourceRequestRecorder.record failed (error: $error)',
             error, stackTrace);
@@ -173,7 +171,7 @@ class GaeCounter implements PersistentCounter {
 }
 
 /*
- * This is the schema for source code storage
+ * This is the schema for source code storage.
  */
 @db.Kind()
 class GaeSourceRecordBlob extends db.Model {

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -55,10 +55,11 @@ class Analyzer {
   void _reset() {
     _resolver = new MemoryResolver();
 
-    DartSdk sdk = new DirectoryBasedDartSdk(new JavaFile(_sdkPath),
-    /*useDart2jsPaths*/ true);
+    DartSdk sdk = new DirectoryBasedDartSdk(new JavaFile(_sdkPath), /*useDart2jsPaths*/ true);
     _context = AnalysisEngine.instance.createAnalysisContext();
-    _context.analysisOptions = new AnalysisOptionsImpl()..cacheSize = 512;
+    AnalysisOptionsImpl options = new AnalysisOptionsImpl();
+    options.cacheSize = 512;
+    _context.analysisOptions = options;
 
     List<UriResolver> resolvers = [
       new DartUriResolver(sdk),
@@ -189,10 +190,11 @@ class Analyzer {
 
     if (node is Expression) {
       Expression expression = node;
-      Map info = {};
+      Map<String, dynamic> info = {};
 
       // element
-      Element element = ElementLocator.locateWithOffset(expression, offset);
+      NodeLocator locator = new NodeLocator(offset);
+      Element element = ElementLocator.locate(locator.searchWithin(expression));
 
       if (element != null) {
         // variable, if synthetic accessor
@@ -239,7 +241,7 @@ class Analyzer {
               if (e.toString().startsWith("@DomName")) {
                 EvaluationResultImpl evaluationResult = e.evaluationResult;
                 if (evaluationResult != null && evaluationResult.value.fields["name"] != null) {
-                  info["DomName"] = evaluationResult.value.fields["name"].value;
+                  info["DomName"] = evaluationResult.value.fields["name"].toStringValue();
                 } else {
                   _logger.fine("WARNING: Unexpected null, aborting");
                 }

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -11,14 +11,14 @@ import 'package:crypto/crypto.dart';
 import 'package:logging/logging.dart';
 import 'package:rpc/rpc.dart';
 
-import 'api_classes.dart';
+import '../version.dart';
 import 'analysis_server.dart';
 import 'analyzer.dart';
+import 'api_classes.dart';
 import 'common.dart';
 import 'compiler.dart';
 import 'pub.dart';
 import 'summarize.dart';
-import '../version.dart';
 
 final Duration _standardExpiration = new Duration(hours: 1);
 final Logger _logger = new Logger('common_server');
@@ -75,7 +75,6 @@ class CommonServer {
     _logger.level = Level.ALL;
 
     pub = enablePackages ? new Pub() : new Pub.mock();
-
     analyzer = new Analyzer(sdkPath);
     compiler = new Compiler(sdkPath, pub);
     analysisServer = new AnalysisServerWrapper(sdkPath);

--- a/lib/src/dartpad_support_server.dart
+++ b/lib/src/dartpad_support_server.dart
@@ -4,15 +4,16 @@
 
 library services.database;
 
-import 'package:rpc/rpc.dart';
 import 'dart:async';
-import 'package:appengine/appengine.dart' as ae;
-import 'package:gcloud/db.dart' as db;
-import 'package:crypto/crypto.dart' as crypto;
 import 'dart:convert' as convert;
 import 'dart:io' as io;
 import 'dart:mirrors' as mirrors;
+
+import 'package:appengine/appengine.dart' as ae;
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:gcloud/db.dart' as db;
 import 'package:logging/logging.dart';
+import 'package:rpc/rpc.dart';
 import 'package:uuid/uuid.dart' as uuid_tools;
 
 final Logger _logger = new Logger('dartpad_support_server');

--- a/lib/src/pub.dart
+++ b/lib/src/pub.dart
@@ -13,8 +13,8 @@ import 'dart:io';
 import 'package:analyzer/src/generated/error.dart';
 import 'package:analyzer/src/generated/scanner.dart';
 import 'package:archive/archive.dart';
-import 'package:logging/logging.dart';
 import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart' as yaml;
 

--- a/lib/src/scheduler.dart
+++ b/lib/src/scheduler.dart
@@ -4,8 +4,8 @@
 
 library services.scheduler;
 
-import 'dart:collection';
 import 'dart:async';
+import 'dart:collection';
 
 class TaskScheduler {
   Queue<_Task> _taskQueue = new Queue();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,21 +3,23 @@ version: 0.0.1
 author: Dart Team <misc@dartlang.org>
 description: The server backend for a web based interactive Dart service.
 homepage: https://github.com/dart-lang/dart-services
+
 environment:
   sdk: '>=1.0.0 <2.0.0'
+
 dependencies:
   analysis_server:
     git:
       url: git://github.com/lukechurch/dart-analysis-server-temp-working.git
       ref: v_1_12_rc0
-  analyzer: '>=0.26.1-alpha.0 <0.27.0'
-  appengine: '>=0.3.0 <0.4.0'
+  analyzer: ^0.26.0
+  appengine: ^0.3.0
   archive: '>=1.0.19 <1.1.0'
   args: '>=0.12.0 <0.14.0'
   cli_util: ^0.0.1
   # `compiler_unsupported` needs to be pegged to a specific version.
-  compiler_unsupported: '1.12.1'
-  crypto: '>=0.9.0 <0.10.0'
+  compiler_unsupported: 1.13.1
+  crypto: ^0.9.0
   librato: '>=0.0.1 <0.1.0'
   logging: '>=0.9.0 <0.12.0'
   path: ^1.3.0
@@ -27,12 +29,14 @@ dependencies:
   rpc: ^0.5.0
   uuid: ^0.5.0
   yaml: ^2.0.0
+
 dev_dependencies:
   _discoveryapis_commons: any
   browser: any
-  codemirror: '>=0.2.0 <0.3.0'
-  grinder: '>=0.7.0 <0.8.0'
+  codemirror: ^0.4.0
+  grinder: ^0.8.0
   http: any
   unittest: ^0.11.0
+
 executables:
   services: null

--- a/test/analyzer_test.dart
+++ b/test/analyzer_test.dart
@@ -4,12 +4,11 @@
 
 library services.analyzer_test;
 
-import 'package:services/src/analyzer.dart';
-import 'package:services/src/common.dart';
 import 'package:cli_util/cli_util.dart' as cli_util;
-import 'package:unittest/unittest.dart';
-
+import 'package:services/src/analyzer.dart';
 import 'package:services/src/api_classes.dart';
+import 'package:services/src/common.dart';
+import 'package:unittest/unittest.dart';
 
 String sdkPath = cli_util.getSdkDir([]).path;
 

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -8,9 +8,9 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:cli_util/cli_util.dart' as cli_util;
+import 'package:rpc/rpc.dart';
 import 'package:services/src/common.dart';
 import 'package:services/src/common_server.dart';
-import 'package:rpc/rpc.dart';
 import 'package:unittest/unittest.dart';
 
 import 'src/test_config.dart';
@@ -66,7 +66,9 @@ void defineTests() {
     assert(apiServer != null);
     var uri = Uri.parse("/api/$path");
     var body = new Stream.fromIterable([UTF8.encode(JSON.encode(json))]);
-    var request = new HttpApiRequest('POST', uri, {}, body);
+    var request = new HttpApiRequest('POST', uri, {
+      'content-type': 'application/json; charset=utf-8'
+    }, body);
     return apiServer.handleHttpApiRequest(request);
   }
 
@@ -75,7 +77,9 @@ void defineTests() {
     var uri = Uri.parse(
         queryParams == null ? "/api/$path" : "/api/$path?$queryParams");
     var body = new Stream.fromIterable([]);
-    var request = new HttpApiRequest('GET', uri, {}, body);
+    var request = new HttpApiRequest('GET', uri, {
+      'content-type': 'application/json; charset=utf-8'
+    }, body);
     return apiServer.handleHttpApiRequest(request);
   }
 
@@ -123,9 +127,9 @@ void defineTests() {
     });
 
     test('analyze negative-test noSource', () async {
-       var json = {};
-       var response = await _sendPostRequest('dartservices/v1/analyze', json);
-       expect(response.status, 400);
+      var json = {};
+      var response = await _sendPostRequest('dartservices/v1/analyze', json);
+      expect(response.status, 400);
     });
 
     test('compile', () async {
@@ -146,9 +150,9 @@ void defineTests() {
     });
 
     test('compile negative-test noSource', () async {
-        var json = {};
-        var response = await _sendPostRequest('dartservices/v1/compile', json);
-        expect(response.status, 400);
+      var json = {};
+      var response = await _sendPostRequest('dartservices/v1/compile', json);
+      expect(response.status, 400);
      });
 
     test('complete', () async {

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -4,9 +4,9 @@
 
 library services.compiler_test;
 
+import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:services/src/common.dart';
 import 'package:services/src/compiler.dart';
-import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:unittest/unittest.dart';
 
 void defineTests() {
@@ -98,10 +98,7 @@ import 'dart:io';
 void main() { print ('foo'); }
 ''';
       return compiler.compile(code).then((CompilationResults result) {
-        expect(result.problems.length, greaterThan(10));
-        List<CompilationProblem> problems = result.problems;
-        expect(problems.any((p) => p.isOnSdk), true);
-        expect(problems.any((p) => !p.isOnCompileTarget), true);
+        expect(result.problems.length, 1);
       });
     });
   });

--- a/test/dartpad_server_test.dart
+++ b/test/dartpad_server_test.dart
@@ -7,9 +7,9 @@ library services.dartpad_server_test;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:rpc/rpc.dart';
 import 'package:services/src/common.dart';
 import 'package:services/src/dartpad_support_server.dart';
-import 'package:rpc/rpc.dart';
 import 'package:unittest/unittest.dart';
 
 String quickFixesCode = r'''
@@ -44,16 +44,19 @@ void defineTests() {
     assert(apiServer != null);
     var uri = Uri.parse("/api/$path");
     var body = new Stream.fromIterable([UTF8.encode(JSON.encode(json))]);
-    var request = new HttpApiRequest('POST', uri, {}, body);
+    var request = new HttpApiRequest('POST', uri, {
+      'content-type': 'application/json; charset=utf-8'
+    }, body);
     return apiServer.handleHttpApiRequest(request);
   }
 
   Future<HttpApiResponse> _sendGetRequest(String path, [String queryParams]) {
     assert(apiServer != null);
-    var uri = Uri
-        .parse(queryParams == null ? "/api/$path" : "/api/$path?$queryParams");
+    var uri = Uri.parse(queryParams == null ? "/api/$path" : "/api/$path?$queryParams");
     var body = new Stream.fromIterable([]);
-    var request = new HttpApiRequest('GET', uri, {}, body);
+    var request = new HttpApiRequest('GET', uri, {
+      'content-type': 'application/json; charset=utf-8'
+    }, body);
     return apiServer.handleHttpApiRequest(request);
   }
 

--- a/test/gae_deployed_test.dart
+++ b/test/gae_deployed_test.dart
@@ -4,8 +4,8 @@
 
 library gaeDeployed_test;
 
-import 'package:services/src/common.dart' as common;
 import 'package:http/http.dart' as http;
+import 'package:services/src/common.dart' as common;
 import 'package:unittest/unittest.dart';
 
 final String serverUrl = "https://liftoff-dev.appspot.com";

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -21,7 +21,7 @@ analyze() {
 }
 
 @Task()
-test() => Dart.run('test/all.dart');
+test() => Dart.runAsync('test/all.dart');
 
 @DefaultTask()
 @Depends(analyze, test)
@@ -110,19 +110,19 @@ discovery() {
   discoveryFile.parent.createSync();
   log('writing ${discoveryFile.path}');
   discoveryFile.writeAsStringSync(result.stdout.trim() + '\n');
-  
+
   ProcessResult resultDb = Process.runSync(
         'dart', ['bin/services.dart', '--discovery', '--relay']);
 
     if (result.exitCode != 0) {
       throw 'Error generating the discovery document\n${result.stderr}';
     }
-    
+
   File discoveryDbFile = new File('doc/generated/_dartpadsupportservices.json');
   discoveryDbFile.parent.createSync();
   log('writing ${discoveryDbFile.path}');
   discoveryDbFile.writeAsStringSync(resultDb.stdout.trim() + '\n');
-  
+
   // Generate the Dart library from the json discovery file.
   Pub.global.activate('discoveryapis_generator');
   Pub.global.run('discoveryapis_generator:generate', arguments: [


### PR DESCRIPTION
Upgrade to `1.13.1`.

- upgrade to `compiler_unsupported` 1.13.1
- fix a regression where we threw an NPE if Platform.packageRoot was null
- fix ~30 unit test failures due to content type handling
- fix an issue with changed compilation errors from dart2js

@lukechurch 

Luke, can you test this w/ appengine when it lands? The local server is working. There were a lot of various changes and fixes to fix regressions, and then to upgrade to the latest packages.

We'll also need to rev from analysis server 1.12.0 to something more recent.