### PR TITLE
Remove librato reporting benchmarks

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   # `compiler_unsupported` needs to be pegged to a specific version.
   compiler_unsupported: 1.16.0
   crypto: ^0.9.0
-  librato: '>=0.0.1 <0.1.0'
   logging: '>=0.9.0 <0.12.0'
   path: ^1.3.0
   shelf: ^0.6.0


### PR DESCRIPTION
@devoncarew TBR

The librato integration is causing a version lock that is preventing me rolling analyzer forwards. I'll need to remove it. If you feel strongly about keeping it we can add it back in again later once we've addressed the version issue