### PR TITLE
change the document and analyze services to use the analysis server

### DIFF
--- a/.atom/launches/services.yaml
+++ b/.atom/launches/services.yaml
@@ -1,8 +1,0 @@
-# Cli launch configuration for bin/services.dart.
-type: cli
-path: bin/services.dart
-
-cli:
-  args: 
-  checked: true
-  debug: true

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ http://dart-services.appspot.com/api/discovery/v1/apis/dartservices/v1/rest.
 
 To run the server, run:
 
-    dart bin/services.dart --port 8082
+    dart bin/server_dev.dart --port 8082
 
 The server will run from port 8082 and export several JSON APIs, like
 `/api/compile` and `/api/analyze`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,7 @@ analyzer:
   strong-mode: true
 linter:
   rules:
+    - always_declare_return_types
     # - annotate_overrides
     - avoid_init_to_null
     - directives_ordering

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,4 +2,9 @@ analyzer:
   strong-mode: true
 linter:
   rules:
+    # - annotate_overrides
+    - avoid_init_to_null
     - directives_ordering
+    - no_adjacent_strings_in_list
+    - package_api_docs
+    # - slash_for_doc_comments

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -7,7 +7,6 @@ library services.bench;
 import 'dart:async';
 
 import 'package:dart_services/src/analysis_server.dart';
-import 'package:dart_services/src/analyzer.dart';
 import 'package:dart_services/src/bench.dart';
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/compiler.dart';
@@ -21,11 +20,9 @@ void main(List<String> args) {
     new AnalyzerBenchmark('hello', sampleCode),
     new AnalyzerBenchmark('hellohtml', sampleCodeWeb),
     new AnalyzerBenchmark('sunflower', _sunflower),
-
     new AnalysisServerBenchmark('hello', sampleCode),
     new AnalysisServerBenchmark('hellohtml', sampleCodeWeb),
     new AnalysisServerBenchmark('sunflower', _sunflower),
-
     new Dart2jsBenchmark('hello', sampleCode),
     new Dart2jsBenchmark('hellohtml', sampleCodeWeb),
     new Dart2jsBenchmark('sunflower', _sunflower),
@@ -36,13 +33,17 @@ void main(List<String> args) {
 
 class AnalyzerBenchmark extends Benchmark {
   final String source;
-  Analyzer analyzer;
+  AnalysisServerWrapper analysisServer;
 
   AnalyzerBenchmark(String name, this.source) : super('analyzer.${name}') {
-    analyzer = new Analyzer(getSdkPath());
+    analysisServer = new AnalysisServerWrapper(getSdkPath());
   }
 
-  Future perform() => analyzer.analyze(source);
+  Future init() => analysisServer.init();
+
+  Future perform() => analysisServer.analyze(source);
+
+  Future tearDown() => analysisServer.shutdown();
 }
 
 class Dart2jsBenchmark extends Benchmark {

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -36,7 +36,7 @@ class AnalyzerBenchmark extends Benchmark {
   AnalysisServerWrapper analysisServer;
 
   AnalyzerBenchmark(String name, this.source) : super('analyzer.${name}') {
-    analysisServer = new AnalysisServerWrapper(getSdkPath());
+    analysisServer = new AnalysisServerWrapper(getSdkPath(), true);
   }
 
   Future init() => analysisServer.init();
@@ -67,7 +67,7 @@ class AnalysisServerBenchmark extends Benchmark {
 
   AnalysisServerBenchmark(String name, this.source)
       : super('completion.${name}') {
-    analysisServer = new AnalysisServerWrapper(getSdkPath());
+    analysisServer = new AnalysisServerWrapper(getSdkPath(), true);
   }
 
   Future init() => analysisServer.init();

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -36,7 +36,7 @@ class AnalyzerBenchmark extends Benchmark {
   AnalysisServerWrapper analysisServer;
 
   AnalyzerBenchmark(String name, this.source) : super('analyzer.${name}') {
-    analysisServer = new AnalysisServerWrapper(getSdkPath(), true);
+    analysisServer = new AnalysisServerWrapper(getSdkPath());
   }
 
   Future init() => analysisServer.init();
@@ -67,7 +67,7 @@ class AnalysisServerBenchmark extends Benchmark {
 
   AnalysisServerBenchmark(String name, this.source)
       : super('completion.${name}') {
-    analysisServer = new AnalysisServerWrapper(getSdkPath(), true);
+    analysisServer = new AnalysisServerWrapper(getSdkPath());
   }
 
   Future init() => analysisServer.init();

--- a/bin/server_dev.dart
+++ b/bin/server_dev.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// A dev-time only server; see `bin/server.dart` for the GAE server.
 library services.bin;
 
-import 'package:dart_services/services_server.dart' as server;
+import 'package:dart_services/services_dev.dart' as services_dev;
 
-void main(List<String> args) => server.main(args);
+void main(List<String> args) => services_dev.main(args);

--- a/doc/generated/_dartpadsupportservices.dart
+++ b/doc/generated/_dartpadsupportservices.dart
@@ -9,17 +9,19 @@ import 'dart:convert' as convert;
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
 import 'package:http/http.dart' as http;
 
-export 'package:_discoveryapis_commons/_discoveryapis_commons.dart' show
-    ApiRequestError, DetailedApiRequestError;
+export 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
+    show ApiRequestError, DetailedApiRequestError;
 
 const core.String USER_AGENT = 'dart-api-client _dartpadsupportservices/v1';
 
 class P_dartpadsupportservicesApi {
-
   final commons.ApiRequester _requester;
 
-  P_dartpadsupportservicesApi(http.Client client, {core.String rootUrl: "/", core.String servicePath: "api/_dartpadsupportservices/v1/"}) :
-      _requester = new commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
+  P_dartpadsupportservicesApi(http.Client client,
+      {core.String rootUrl: "/",
+      core.String servicePath: "api/_dartpadsupportservices/v1/"})
+      : _requester =
+            new commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
 
   /**
    * Store a gist dataset to be retrieved.
@@ -50,13 +52,12 @@ class P_dartpadsupportservicesApi {
 
     _url = 'export';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new UuidContainer.fromJson(data));
   }
 
@@ -79,16 +80,14 @@ class P_dartpadsupportservicesApi {
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
 
-
     _url = 'getUnusedMappingId';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new UuidContainer.fromJson(data));
   }
 
@@ -121,13 +120,12 @@ class P_dartpadsupportservicesApi {
 
     _url = 'pullExportData';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new PadSaveObject.fromJson(data));
   }
 
@@ -158,13 +156,12 @@ class P_dartpadsupportservicesApi {
 
     _url = 'retrieveGist';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new UuidContainer.fromJson(data));
   }
 
@@ -195,19 +192,15 @@ class P_dartpadsupportservicesApi {
 
     _url = 'storeGist';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new UuidContainer.fromJson(data));
   }
-
 }
-
-
 
 class GistToInternalIdMapping {
   core.String gistId;

--- a/doc/generated/_dartpadsupportservices.dart
+++ b/doc/generated/_dartpadsupportservices.dart
@@ -1,6 +1,6 @@
 // This is a generated file (see the discoveryapis_generator project).
 
-library services.P_dartpadsupportservices.v1;
+library dart_services.P_dartpadsupportservices.v1;
 
 import 'dart:core' as core;
 import 'dart:async' as async;

--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -9,17 +9,19 @@ import 'dart:convert' as convert;
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
 import 'package:http/http.dart' as http;
 
-export 'package:_discoveryapis_commons/_discoveryapis_commons.dart' show
-    ApiRequestError, DetailedApiRequestError;
+export 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
+    show ApiRequestError, DetailedApiRequestError;
 
 const core.String USER_AGENT = 'dart-api-client dartservices/v1';
 
 class DartservicesApi {
-
   final commons.ApiRequester _requester;
 
-  DartservicesApi(http.Client client, {core.String rootUrl: "/", core.String servicePath: "api/dartservices/v1/"}) :
-      _requester = new commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
+  DartservicesApi(http.Client client,
+      {core.String rootUrl: "/",
+      core.String servicePath: "api/dartservices/v1/"})
+      : _requester =
+            new commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
 
   /**
    * Analyze the given Dart source code and return any resulting analysis errors
@@ -51,13 +53,12 @@ class DartservicesApi {
 
     _url = 'analyze';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new AnalysisResults.fromJson(data));
   }
 
@@ -76,7 +77,8 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<AnalysisResults> analyzeGet({core.String source, core.bool strongMode}) {
+  async.Future<AnalysisResults> analyzeGet(
+      {core.String source, core.bool strongMode}) {
     var _url = null;
     var _queryParams = new core.Map();
     var _uploadMedia = null;
@@ -93,13 +95,12 @@ class DartservicesApi {
 
     _url = 'analyze';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new AnalysisResults.fromJson(data));
   }
 
@@ -133,13 +134,12 @@ class DartservicesApi {
 
     _url = 'analyzeMulti';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new AnalysisResults.fromJson(data));
   }
 
@@ -172,13 +172,12 @@ class DartservicesApi {
 
     _url = 'compile';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new CompileResponse.fromJson(data));
   }
 
@@ -209,13 +208,12 @@ class DartservicesApi {
 
     _url = 'compile';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new CompileResponse.fromJson(data));
   }
 
@@ -248,13 +246,12 @@ class DartservicesApi {
 
     _url = 'complete';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new CompleteResponse.fromJson(data));
   }
 
@@ -273,7 +270,8 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<CompleteResponse> completeGet({core.String source, core.int offset}) {
+  async.Future<CompleteResponse> completeGet(
+      {core.String source, core.int offset}) {
     var _url = null;
     var _queryParams = new core.Map();
     var _uploadMedia = null;
@@ -290,13 +288,12 @@ class DartservicesApi {
 
     _url = 'complete';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new CompleteResponse.fromJson(data));
   }
 
@@ -329,13 +326,12 @@ class DartservicesApi {
 
     _url = 'completeMulti';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new CompleteResponse.fromJson(data));
   }
 
@@ -366,13 +362,12 @@ class DartservicesApi {
 
     _url = 'counter';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new CounterResponse.fromJson(data));
   }
 
@@ -406,13 +401,12 @@ class DartservicesApi {
 
     _url = 'document';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new DocumentResponse.fromJson(data));
   }
 
@@ -431,7 +425,8 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<DocumentResponse> documentGet({core.String source, core.int offset}) {
+  async.Future<DocumentResponse> documentGet(
+      {core.String source, core.int offset}) {
     var _url = null;
     var _queryParams = new core.Map();
     var _uploadMedia = null;
@@ -448,13 +443,12 @@ class DartservicesApi {
 
     _url = 'document';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new DocumentResponse.fromJson(data));
   }
 
@@ -487,13 +481,12 @@ class DartservicesApi {
 
     _url = 'fixes';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new FixesResponse.fromJson(data));
   }
 
@@ -529,13 +522,12 @@ class DartservicesApi {
 
     _url = 'fixes';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new FixesResponse.fromJson(data));
   }
 
@@ -568,13 +560,12 @@ class DartservicesApi {
 
     _url = 'fixesMulti';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new FixesResponse.fromJson(data));
   }
 
@@ -609,13 +600,12 @@ class DartservicesApi {
 
     _url = 'format';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new FormatResponse.fromJson(data));
   }
 
@@ -634,7 +624,8 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<FormatResponse> formatGet({core.String source, core.int offset}) {
+  async.Future<FormatResponse> formatGet(
+      {core.String source, core.int offset}) {
     var _url = null;
     var _queryParams = new core.Map();
     var _uploadMedia = null;
@@ -651,13 +642,12 @@ class DartservicesApi {
 
     _url = 'format';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new FormatResponse.fromJson(data));
   }
 
@@ -691,13 +681,12 @@ class DartservicesApi {
 
     _url = 'summarize';
 
-    var _response = _requester.request(_url,
-                                       "POST",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new SummaryText.fromJson(data));
   }
 
@@ -722,22 +711,17 @@ class DartservicesApi {
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
 
-
     _url = 'version';
 
-    var _response = _requester.request(_url,
-                                       "GET",
-                                       body: _body,
-                                       queryParams: _queryParams,
-                                       uploadOptions: _uploadOptions,
-                                       uploadMedia: _uploadMedia,
-                                       downloadOptions: _downloadOptions);
+    var _response = _requester.request(_url, "GET",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
     return _response.then((data) => new VersionResponse.fromJson(data));
   }
-
 }
-
-
 
 class AnalysisIssue {
   core.int charLength;
@@ -810,7 +794,9 @@ class AnalysisResults {
 
   AnalysisResults.fromJson(core.Map _json) {
     if (_json.containsKey("issues")) {
-      issues = _json["issues"].map((value) => new AnalysisIssue.fromJson(value)).toList();
+      issues = _json["issues"]
+          .map((value) => new AnalysisIssue.fromJson(value))
+          .toList();
     }
     if (_json.containsKey("packageImports")) {
       packageImports = _json["packageImports"];
@@ -837,7 +823,9 @@ class CandidateFix {
 
   CandidateFix.fromJson(core.Map _json) {
     if (_json.containsKey("edits")) {
-      edits = _json["edits"].map((value) => new SourceEdit.fromJson(value)).toList();
+      edits = _json["edits"]
+          .map((value) => new SourceEdit.fromJson(value))
+          .toList();
     }
     if (_json.containsKey("message")) {
       message = _json["message"];
@@ -1005,7 +993,9 @@ class FixesResponse {
 
   FixesResponse.fromJson(core.Map _json) {
     if (_json.containsKey("fixes")) {
-      fixes = _json["fixes"].map((value) => new ProblemAndFixes.fromJson(value)).toList();
+      fixes = _json["fixes"]
+          .map((value) => new ProblemAndFixes.fromJson(value))
+          .toList();
     }
   }
 
@@ -1084,7 +1074,9 @@ class ProblemAndFixes {
 
   ProblemAndFixes.fromJson(core.Map _json) {
     if (_json.containsKey("fixes")) {
-      fixes = _json["fixes"].map((value) => new CandidateFix.fromJson(value)).toList();
+      fixes = _json["fixes"]
+          .map((value) => new CandidateFix.fromJson(value))
+          .toList();
     }
     if (_json.containsKey("length")) {
       length = _json["length"];

--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -1,10 +1,10 @@
 // This is a generated file (see the discoveryapis_generator project).
 
-library services.dartservices.v1;
+library dart_services.dartservices.v1;
 
+import 'dart:core' as core;
 import 'dart:async' as async;
 import 'dart:convert' as convert;
-import 'dart:core' as core;
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
 import 'package:http/http.dart' as http;
@@ -745,8 +745,6 @@ class AnalysisIssue {
   core.bool hasFixes;
   core.String kind;
   core.int line;
-  /** deprecated - see `sourceName` */
-  core.String location;
   core.String message;
   core.String sourceName;
 
@@ -767,9 +765,6 @@ class AnalysisIssue {
     }
     if (_json.containsKey("line")) {
       line = _json["line"];
-    }
-    if (_json.containsKey("location")) {
-      location = _json["location"];
     }
     if (_json.containsKey("message")) {
       message = _json["message"];
@@ -796,9 +791,6 @@ class AnalysisIssue {
     if (line != null) {
       _json["line"] = line;
     }
-    if (location != null) {
-      _json["location"] = location;
-    }
     if (message != null) {
       _json["message"] = message;
     }
@@ -813,8 +805,6 @@ class AnalysisResults {
   core.List<AnalysisIssue> issues;
   /** The package imports parsed from the source. */
   core.List<core.String> packageImports;
-  /** The resolved imports - e.g. dart:async, dart:io, ... */
-  core.List<core.String> resolvedImports;
 
   AnalysisResults();
 
@@ -825,9 +815,6 @@ class AnalysisResults {
     if (_json.containsKey("packageImports")) {
       packageImports = _json["packageImports"];
     }
-    if (_json.containsKey("resolvedImports")) {
-      resolvedImports = _json["resolvedImports"];
-    }
   }
 
   core.Map toJson() {
@@ -837,9 +824,6 @@ class AnalysisResults {
     }
     if (packageImports != null) {
       _json["packageImports"] = packageImports;
-    }
-    if (resolvedImports != null) {
-      _json["resolvedImports"] = resolvedImports;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "72a6d262af61307d87c36f58a6adab2df709a1d4",
+ "etag": "346d056e776eb948fc9790c24393ea4ccf6e46e9",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -59,13 +59,6 @@
      "items": {
       "type": "string"
      }
-    },
-    "resolvedImports": {
-     "type": "array",
-     "description": "The resolved imports - e.g. dart:async, dart:io, ...",
-     "items": {
-      "type": "string"
-     }
     }
    }
   },
@@ -96,10 +89,6 @@
     "charLength": {
      "type": "integer",
      "format": "int32"
-    },
-    "location": {
-     "type": "string",
-     "description": "deprecated - see `sourceName`"
     }
    }
   },

--- a/example/apitest.dart
+++ b/example/apitest.dart
@@ -35,7 +35,7 @@ void setupDartpadServices() {
   setupGistRetrieval();
 }
 
-_setupClients() {
+void _setupClients() {
   client = new utils.SanitizingBrowserClient();
   servicesApi = new services.DartservicesApi(client, rootUrl: _uriBase);
   _dartpadSupportApi =

--- a/example/apitest.dart
+++ b/example/apitest.dart
@@ -250,10 +250,6 @@ CodeMirror createEditor(Element element, {String defaultText}) {
   editor.refresh();
   return editor;
 }
-//
-//String _printHeaders(Map m) {
-//  return m.keys.map((k) => '${k}: ${m[k]}').join('\n');
-//}
 
 String _formatTiming(Stopwatch sw) => "${sw.elapsedMilliseconds}ms\n";
 

--- a/example/index.dart
+++ b/example/index.dart
@@ -5,7 +5,7 @@
 import "dart:convert";
 import "dart:html";
 
-main() {
+void main() {
   querySelector('#sendButton').onClick.listen((e) {
     String code = querySelector('#code').text;
     var json = {'source': code};

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services;
+/// A dev-time only server.
+library services_dev;
 
 import 'dart:async';
 import 'dart:convert';
@@ -36,11 +37,6 @@ void main(List<String> args) {
   });
 
   String sdk = getSdkPath(args);
-  if (sdk == null) {
-    stdout.writeln("Could not locate the SDK; "
-        "please start the server with the '--dart-sdk' option.");
-    exit(1);
-  }
 
   printExit(String doc) {
     print(doc);

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -38,7 +38,7 @@ void main(List<String> args) {
 
   String sdk = getSdkPath(args);
 
-  printExit(String doc) {
+  void printExit(String doc) {
     print(doc);
     exit(0);
   }

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -198,8 +198,8 @@ class _Recorder implements SourceRequestRecorder {
 }
 
 /**
- * This is a mock implementation of a counter, it doesn't use
- * a proper persistent store.
+ * This is a mock implementation of a counter, it doesn't use a proper
+ * persistent store.
  */
 class _Counter implements PersistentCounter {
   final Map<String, int> _map = {};

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -39,7 +39,7 @@ class AnalysisServerWrapper {
   /// Instance to handle communication with the server.
   AnalysisServer analysisServer;
 
-  AnalysisServerWrapper(this.sdkPath) {
+  AnalysisServerWrapper(this.sdkPath, bool useStrongMode) {
     _logger.info("AnalysisServerWrapper ctor");
     sourceDirectory = Directory.systemTemp.createTempSync('analysisServer');
     mainPath = _getPathFromName(kMainDart);
@@ -48,7 +48,7 @@ class AnalysisServerWrapper {
 
     // Write an analysis_options.yaml file with strong mode enabled.
     File optionsFile = new File(_getPathFromName('analysis_options.yaml'));
-    optionsFile.writeAsStringSync('analyzer:\n  strong-mode: true\n');
+    optionsFile.writeAsStringSync('analyzer:\n  strong-mode: ${useStrongMode}\n');
   }
 
   Future init() {

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -39,8 +39,8 @@ class AnalysisServerWrapper {
   /// Instance to handle communication with the server.
   AnalysisServer analysisServer;
 
-  AnalysisServerWrapper(this.sdkPath, bool useStrongMode) {
-    _logger.info("AnalysisServerWrapper ctor");
+  AnalysisServerWrapper(this.sdkPath, {bool strongMode: true}) {
+    _logger.info('AnalysisServerWrapper ctor, strong mode: $strongMode');
     sourceDirectory = Directory.systemTemp.createTempSync('analysisServer');
     mainPath = _getPathFromName(kMainDart);
 
@@ -48,7 +48,7 @@ class AnalysisServerWrapper {
 
     // Write an analysis_options.yaml file with strong mode enabled.
     File optionsFile = new File(_getPathFromName('analysis_options.yaml'));
-    optionsFile.writeAsStringSync('analyzer:\n  strong-mode: ${useStrongMode}\n');
+    optionsFile.writeAsStringSync('analyzer:\n  strong-mode: ${strongMode}\n');
   }
 
   Future init() {

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -43,7 +43,6 @@ class Analyzer {
 
   Analyzer(this._sdkPath, {this.pub, this.strongMode: false}) {
     _reset();
-    analyze('');
   }
 
   void _reset() {

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -148,7 +148,6 @@ class Analyzer {
         packageImports.addAll(
             filterSafePackagesFromImports(getAllUnsafeImportsFor(source)));
       }
-      List<String> resolvedImports = _calculateImports(_context, sourcesList);
 
       // Delete the files
       changeSet = new ChangeSet();
@@ -162,8 +161,8 @@ class Analyzer {
       _context.applyChanges(changeSet);
       _ensureAnalysisDone(_context, _MAX_ANALYSIS_DURATION);
 
-      return new Future.value(new AnalysisResults(
-          issues, packageImports.toList(), resolvedImports));
+      return new Future.value(
+          new AnalysisResults(issues, packageImports.toList()));
     } catch (e, st) {
       _reset();
       return new Future.error(e, st);
@@ -305,25 +304,6 @@ class Analyzer {
     }
 
     return null;
-  }
-
-  /// Calculate the resolved imports for the given set of sources.
-  List<String> _calculateImports(
-      AnalysisContext context, List<Source> sources) {
-    Set<String> imports = new Set();
-
-    for (Source source in sources) {
-      LibraryElement element = context.getLibraryElement(source);
-
-      if (element != null) {
-        element.imports.forEach((ImportElement import) {
-          // The dart:core implicit import has a null uri.
-          if (import.uri != null) imports.add(import.uri);
-        });
-      }
-    }
-
-    return imports.toList();
   }
 
   // TODO(lukechurch): Determine whether we can change this in the Analyzer.

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -187,6 +187,7 @@ class Analyzer {
     }
   }
 
+  @deprecated
   Future<Map<String, String>> dartdoc(String source, int offset) {
     try {
       var _source = new StringSource(source, kMainDart);
@@ -242,8 +243,6 @@ class Analyzer {
         // Only defined if there is an enclosing class.
         if (element.enclosingElement is ClassElement) {
           info['enclosingClassName'] = '${element.enclosingElement}';
-        } else {
-          info['enclosingClassName'] = null;
         }
 
         // Parameters for functions and methods.

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -15,11 +15,7 @@ class AnalysisResults {
   @ApiProperty(description: 'The package imports parsed from the source.')
   final List<String> packageImports;
 
-  @ApiProperty(
-      description: 'The resolved imports - e.g. dart:async, dart:io, ...')
-  final List<String> resolvedImports;
-
-  AnalysisResults(this.issues, this.packageImports, this.resolvedImports);
+  AnalysisResults(this.issues, this.packageImports);
 }
 
 class AnalysisIssue implements Comparable<AnalysisIssue> {

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -34,10 +34,7 @@ class AnalysisIssue implements Comparable<AnalysisIssue> {
   final int charLength;
 
   AnalysisIssue.fromIssue(this.kind, this.line, this.message,
-      {this.charStart,
-      this.charLength,
-      this.sourceName,
-      this.hasFixes: false});
+      {this.charStart, this.charLength, this.sourceName, this.hasFixes: false});
 
   Map toMap() {
     Map m = {'kind': kind, 'line': line, 'message': message};

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -64,6 +64,16 @@ void main() {
 }
 """;
 
+final String sampleStrongError = """
+void main() {
+  foo('whoops');
+}
+
+void foo(int i) {
+  print(i);
+}
+""";
+
 class Lines {
   List<int> _starts = [];
 

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -79,8 +79,8 @@ class CommonServer {
     strongModeAnalyzer = new Analyzer(sdkPath, strongMode: true);
     analyzer = new Analyzer(sdkPath);
     compiler = new Compiler(sdkPath, pub);
-    analysisServer = new AnalysisServerWrapper(sdkPath, false);
-    analysisServerStrong = new AnalysisServerWrapper(sdkPath, true);
+    analysisServer = new AnalysisServerWrapper(sdkPath, strongMode: false);
+    analysisServerStrong = new AnalysisServerWrapper(sdkPath);
   }
 
   Future init() async {

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -411,21 +411,14 @@ class CommonServer {
     srcRequestRecorder.record("DOCUMENT", source, offset);
     _logger.info("About to DOCUMENT: ${_hashSource(source)}");
     try {
-      return analyzer
-          .dartdoc(source, offset)
-          .then((Map<String, String> docInfo) async {
-        if (docInfo == null) docInfo = {};
-        _logger
-            .info('PERF: Computed dartdoc in ${watch.elapsedMilliseconds}ms.');
-        counter.increment("DartDocs");
-        return new DocumentResponse(docInfo);
-      }).catchError((e, st) {
-        _logger.severe('Error during dartdoc: ${e}\n${st}');
-        throw e;
-      });
+      Map<String, String> docInfo = await analysisServer.dartdoc(source, offset);
+      docInfo ??= {};
+      _logger.info('PERF: Computed dartdoc in ${watch.elapsedMilliseconds}ms.');
+      counter.increment("DartDocs");
+      return new DocumentResponse(docInfo);
     } catch (e, st) {
-      _logger.severe('Error during dartdoc: ${e}\n${st}');
-      throw e;
+      _logger.severe('Error during dartdoc', e, st);
+      rethrow;
     }
   }
 

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -68,7 +68,8 @@ class Compiler {
       mainDart.writeAsStringSync(input);
 
       File mainJs = new File(path.join(temp.path, '${kMainDart}.js'));
-      File mainSourceMap = new File(path.join(temp.path, '${kMainDart}.js.map'));
+      File mainSourceMap =
+          new File(path.join(temp.path, '${kMainDart}.js.map'));
 
       ProcessResult result = Process.runSync(
           path.join(sdkPath, 'bin', 'dart2js'), arguments,

--- a/lib/src/pub.dart
+++ b/lib/src/pub.dart
@@ -214,7 +214,7 @@ class Pub {
  * support without having to change the code using the `Pub` class.
  */
 class _MockPub implements Pub {
-  Directory _cacheDir = null;
+  Directory _cacheDir;
 
   _MockPub();
 

--- a/lib/src/scheduler.dart
+++ b/lib/src/scheduler.dart
@@ -44,7 +44,7 @@ class TaskScheduler {
 
 // Internal unit of scheduling.
 class _Task {
-  final task;
+  final Task task;
   final Completer taskResult;
   _Task(this.task, this.taskResult);
 }

--- a/lib/src/summarize.dart
+++ b/lib/src/summarize.dart
@@ -245,7 +245,6 @@ class Summarizer {
       summary += '${_featureList(_codeSearch())}';
       summary += '${_htmlCSS()}';
       summary += '${_packageList(storage.packageImports, source: 'packages')}';
-      summary += '${_packageList(storage.resolvedImports)}';
       summary += '${_additionList(_additionSearch())}';
       return summary.trim();
     } else {
@@ -269,7 +268,6 @@ class Summarizer {
 class _SummarizeToken {
   int linesCode;
   int packageCount;
-  int resolvedCount;
   int errorCount;
   int warningCount;
 
@@ -277,7 +275,6 @@ class _SummarizeToken {
   bool warningPresent;
 
   List<String> packageImports;
-  List<String> resolvedImports;
 
   List<AnalysisIssue> errors;
 
@@ -287,9 +284,7 @@ class _SummarizeToken {
       errorPresent = analysis.issues.any((issue) => issue.kind == 'error');
       warningPresent = analysis.issues.any((issue) => issue.kind == 'warning');
       packageCount = analysis.packageImports.length;
-      resolvedCount = analysis.resolvedImports.length;
       packageImports = analysis.packageImports;
-      resolvedImports = analysis.resolvedImports;
       errors = analysis.issues;
       errorCount = errors.length;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ^0.30.0
-  analysis_server_lib: 0.0.1
+  analysis_server_lib: ^0.1.0
   appengine: 0.4.0-flex.alpha.0+3
   archive: '>=1.0.19 <1.1.0'
   args: '>=0.12.0 <0.14.0'

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -54,7 +54,7 @@ void defineTests() {
 
   group('analysis_server', () {
     setUp(() async {
-      analysisServer = new AnalysisServerWrapper(sdkPath, true);
+      analysisServer = new AnalysisServerWrapper(sdkPath);
       await analysisServer.init();
     });
 
@@ -143,7 +143,7 @@ void defineTests() {
     test('analyze non strong', () async {
       await analysisServer.shutdown();
 
-      analysisServer = new AnalysisServerWrapper(sdkPath, false);
+      analysisServer = new AnalysisServerWrapper(sdkPath, strongMode: false);
       await analysisServer.init();
 
       AnalysisResults results = await analysisServer.analyze(sampleStrongError);

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -54,7 +54,7 @@ void defineTests() {
 
   group('analysis_server', () {
     setUp(() async {
-      analysisServer = new AnalysisServerWrapper(sdkPath);
+      analysisServer = new AnalysisServerWrapper(sdkPath, true);
       await analysisServer.init();
     });
 
@@ -121,6 +121,35 @@ void defineTests() {
     test('format with issues', () async {
       FormatResponse results = await analysisServer.format(formatWithIssues, 0);
       expect(results.newString, formatWithIssues);
+    });
+
+    test('analyze', () async {
+      AnalysisResults results = await analysisServer.analyze(sampleCode);
+      expect(results.issues, isEmpty);
+    });
+
+    test('analyze with errors', () async {
+      AnalysisResults results = await analysisServer.analyze(sampleCodeError);
+      expect(results.issues, hasLength(1));
+    });
+
+    test('analyze strong', () async {
+      AnalysisResults results = await analysisServer.analyze(sampleStrongError);
+      expect(results.issues, hasLength(1));
+      AnalysisIssue issue = results.issues.first;
+      expect(issue.kind, 'error');
+    });
+
+    test('analyze non strong', () async {
+      await analysisServer.shutdown();
+
+      analysisServer = new AnalysisServerWrapper(sdkPath, false);
+      await analysisServer.init();
+
+      AnalysisResults results = await analysisServer.analyze(sampleStrongError);
+      expect(results.issues, hasLength(1));
+      AnalysisIssue issue = results.issues.first;
+      expect(issue.kind, 'warning');
     });
   });
 }

--- a/test/analyzer_test.dart
+++ b/test/analyzer_test.dart
@@ -117,31 +117,28 @@ void main() {
 ''';
 
       return analyzer.analyze(sample).then((AnalysisResults results) {
-        expect(results.packageImports.length, 2);
+        expect(results.packageImports, hasLength(2));
         expect(results.packageImports[0], 'bar');
         expect(results.packageImports[1], 'baz');
-        // expect(results.resolvedImports.length, 2);
-        expect(results.resolvedImports[0], 'dart:async');
-        expect(results.resolvedImports[1], 'dart:io');
       });
     });
 
     test('errors', () {
       return analyzer.analyze(sampleCodeError).then((AnalysisResults results) {
-        expect(results.issues.length, 1);
+        expect(results.issues, hasLength(1));
       });
     });
 
     test('errors many', () {
       return analyzer.analyze(sampleCodeErrors).then((AnalysisResults results) {
-        expect(results.issues.length, 3);
+        expect(results.issues, hasLength(3));
       });
     });
 
     test('missing ;', () {
       final String sample = "void main() {\n  int i = 55\n}";
       return analyzer.analyze(sample).then((AnalysisResults results) {
-        expect(results.issues.length, 2);
+        expect(results.issues, hasLength(2));
         int _missingSemiC = 0;
         results.issues
             .where((issue) => issue.message.contains("Expected to find ';'"))

--- a/test/analyzer_test.dart
+++ b/test/analyzer_test.dart
@@ -167,6 +167,7 @@ void main() {
     });
 
     test('simple', () {
+      // ignore: deprecated_member_use
       return analyzer.dartdoc(sampleCode, 17).then((Map m) {
         expect(m['name'], 'print');
         expect(m['dartdoc'], isNotEmpty);
@@ -181,6 +182,7 @@ void main() {
 }
 ''';
 
+      // ignore: deprecated_member_use
       return analyzer.dartdoc(source, 47).then((Map m) {
         expect(m['name'], 'foo');
         expect(m['propagatedType'], 'String');
@@ -198,6 +200,7 @@ void main() {
 Future foo() => new Future.value(4);
 ''';
 
+      // ignore: deprecated_member_use
       return analyzer.dartdoc(source, 39).then((Map m) {
         expect(m['name'], 'foo');
         expect(m['description'], 'foo() → Future');
@@ -214,6 +217,7 @@ void main() {
 }
 ''';
 
+      // ignore: deprecated_member_use
       return analyzer.dartdoc(source, 44).then((Map m) {
         expect(m['name'], 'DivElement');
         expect(m['libraryName'], 'dart:html');
@@ -228,6 +232,7 @@ main() {
   f.then((x) => x);
 }''';
 
+      // ignore: deprecated_member_use
       return analyzer.dartdoc(source, 84).then((Map m) {
         expect(m, null);
       });

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -98,8 +98,8 @@ void defineTests() {
       var response = await _sendPostRequest('dartservices/v1/analyze', json);
       expect(response.status, 200);
       var data = await response.body.first;
-      expect(JSON.decode(UTF8.decode(data)),
-          {'issues': [], 'packageImports': [], 'resolvedImports': []});
+      expect(
+          JSON.decode(UTF8.decode(data)), {'issues': [], 'packageImports': []});
     });
 
     test('analyze errors', () async {
@@ -121,8 +121,7 @@ void defineTests() {
             "charLength": 1
           }
         ],
-        'packageImports': [],
-        'resolvedImports': []
+        'packageImports': []
       };
       expect(JSON.decode(UTF8.decode(data)), expectedJson);
     });

--- a/test/gae_deployed_test.dart
+++ b/test/gae_deployed_test.dart
@@ -19,7 +19,7 @@ void defineTests({bool skip: true}) {
   });
 }
 
-analyzeTest() {
+void analyzeTest() {
   final String url = '${serverUrl}/api/analyze';
   Map headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 
@@ -34,7 +34,7 @@ analyzeTest() {
       completion(equals(true)));
 }
 
-compileTest() {
+void compileTest() {
   final String url = '${serverUrl}/api/compile';
   Map headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -135,7 +135,8 @@ Future setupTools(String sdkPath) async {
   apiServer = new ApiServer(apiPrefix: '/api', prettyPrint: true)
     ..addApi(server);
 
-  analysisServer = new analysis_server.AnalysisServerWrapper(sdkPath, true);
+  // TODO: We should driver both strong and non-strong modes in the fuzzer.
+  analysisServer = new analysis_server.AnalysisServerWrapper(sdkPath);
   await analysisServer.init();
 
   print("Warming up analysis server");
@@ -435,10 +436,6 @@ final int termWidth = io.stdout.hasTerminal ? io.stdout.terminalColumns : 200;
 
 void log(dynamic obj) {
   if (_VERBOSE) {
-    String str = '${new DateTime.now()} $obj';
-    if (str.length > termWidth) {
-      str = str.substring(0, termWidth - 4) + '...';
-    }
-    print(str);
+    print("${new DateTime.now()} $obj");
   }
 }

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -135,7 +135,7 @@ Future setupTools(String sdkPath) async {
   apiServer = new ApiServer(apiPrefix: '/api', prettyPrint: true)
     ..addApi(server);
 
-  analysisServer = new analysis_server.AnalysisServerWrapper(sdkPath);
+  analysisServer = new analysis_server.AnalysisServerWrapper(sdkPath, true);
   await analysisServer.init();
 
   print("Warming up analysis server");

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -50,7 +50,7 @@ void buildbot() => null;
 @Task('Generate the discovery doc and Dart library from the annotated API')
 discovery() {
   ProcessResult result =
-      Process.runSync('dart', ['bin/services.dart', '--discovery']);
+      Process.runSync('dart', ['bin/server_dev.dart', '--discovery']);
 
   if (result.exitCode != 0) {
     throw 'Error generating the discovery document\n${result.stderr}';
@@ -62,7 +62,7 @@ discovery() {
   discoveryFile.writeAsStringSync(result.stdout.trim() + '\n');
 
   ProcessResult resultDb =
-      Process.runSync('dart', ['bin/services.dart', '--discovery', '--relay']);
+      Process.runSync('dart', ['bin/server_dev.dart', '--discovery', '--relay']);
 
   if (result.exitCode != 0) {
     throw 'Error generating the discovery document\n${result.stderr}';

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -4,28 +4,29 @@
 
 library services.grind;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:grinder/grinder.dart';
 
 Map get _env => Platform.environment;
 
-main(List<String> args) => grind(args);
+Future main(List<String> args) => grind(args);
 
 @Task()
-analyze() {
+void analyze() {
   new PubApp.global('tuneup')..run(['check']);
 }
 
 @Task()
-test() => new TestRunner().testAsync();
+Future test() => new TestRunner().testAsync();
 
 @DefaultTask()
 @Depends(analyze, test)
-analyzeTest() => null;
+void analyzeTest() => null;
 
 @Task()
-coverage() {
+void coverage() {
   if (!_env.containsKey('REPO_TOKEN')) {
     log("env var 'REPO_TOKEN' not found");
     return;
@@ -48,7 +49,7 @@ coverage() {
 void buildbot() => null;
 
 @Task('Generate the discovery doc and Dart library from the annotated API')
-discovery() {
+void discovery() {
   ProcessResult result =
       Process.runSync('dart', ['bin/server_dev.dart', '--discovery']);
 
@@ -61,8 +62,8 @@ discovery() {
   log('writing ${discoveryFile.path}');
   discoveryFile.writeAsStringSync(result.stdout.trim() + '\n');
 
-  ProcessResult resultDb =
-      Process.runSync('dart', ['bin/server_dev.dart', '--discovery', '--relay']);
+  ProcessResult resultDb = Process
+      .runSync('dart', ['bin/server_dev.dart', '--discovery', '--relay']);
 
   if (result.exitCode != 0) {
     throw 'Error generating the discovery document\n${result.stderr}';

--- a/tool/load_driver.dart
+++ b/tool/load_driver.dart
@@ -29,7 +29,7 @@ void main(List<String> args) {
   new Timer.periodic(new Duration(milliseconds: ms), (t) => pingServer(t));
 }
 
-pingServer(Timer t) {
+void pingServer(Timer t) {
   count++;
 
   if (count > 1000) {

--- a/tool/warmup.dart
+++ b/tool/warmup.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert' as convert;
 
 import 'package:http/http.dart' as http;
@@ -13,7 +14,7 @@ const BASE_URI = "dart-services.appspot.com/api/dartservices/v1/";
 // const BASE_URI = "localhost:8080/api/dartservices/v1/";
 const count = 100;
 
-main(List<String> args) async {
+Future main(List<String> args) async {
   String appPrefix;
   if (args.length > 0) {
     appPrefix = "${args[0]}.";
@@ -47,7 +48,7 @@ main(List<String> args) async {
   }
 }
 
-request(String verb, String postPayload) async {
+Future request(String verb, String postPayload) async {
   Stopwatch sw = new Stopwatch()..start();
 
   var response = await http.post(Uri.parse(uri + verb),


### PR DESCRIPTION
- change the document and analyze services to use the analysis server (work towards https://github.com/dart-lang/dart-services/issues/297)
- rename `bin/services.dart` to `bin/server_dev.dart` to make it clear that it's not the prod server
- upgrade to the latest `analysis_server_lib` lib version
- fix a race condition with getFixes, completions, and document (found using the fuzz tester)
- update the benchmarks and fuzz tester to use the analysis server based services

@lukechurch, @danrubel - things are looking good - dartpad (client and server) work locally, tests pass, and the fuzz tester seems happy.
