### PR TITLE
Compiler from image

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -83,6 +83,7 @@ class Compiler {
 
       // Due to an issue with the VM we need to use the Dart2JS instance from
       // the image, not from the downloaded SDK
+      // TODO(#327): Use the compiler from the downloaded SDK
 
       final dartPath =  Platform.resolvedExecutable;
 

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -101,7 +101,6 @@ class Compiler {
       if (result.exitCode != 0) {
         CompilationResults results = new CompilationResults();
         results._problems.add(new CompilationProblem._(result.stdout));
-        results._problems.add(new CompilationProblem._(result.stderr));
         return results;
       } else {
         CompilationResults results = new CompilationResults();

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -113,6 +113,7 @@ class Compiler {
       }
     } catch (e, st) {
       _logger.warning("Compiler failed: $e /n $st");
+      rethrow;
     } finally {
       temp.deleteSync(recursive: true);
       _logger.info('temp folder removed: ${temp.path}');

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -86,6 +86,30 @@ void defineTests() {
       });
     });
 
+    test('import_test', () {
+      String testCode = "import '/'; main() { int a = 0; a. }";
+
+      //Just after i.
+      return analysisServer
+          .complete(testCode, 9)
+          .then((CompleteResponse results) {
+        expect(results.completions.every((Map<String, String> completion) {
+          return completion["completion"].startsWith("dart:");
+        }), true);
+      });
+    });
+
+    test('import_and_other_test', () {
+      String testCode = "import '/'; main() { int a = 0; a. }";
+
+      //Just after i.
+      return analysisServer
+          .complete(testCode, 34)
+          .then((CompleteResponse results) {
+        expect(completionsContains(results, "abs"), true);
+      });
+    });
+
     test('simple_quickFix', () {
       //Just after i.
       return analysisServer


### PR DESCRIPTION
@devoncarew @danrubel: Until we find the underlying cause of a problem need to use the compiler from the AppEngine image not from the downloaded SDK.

This makes that change, and also adds a test to the Analysis server code to ensure we're not offering completions on path imports