### PR TITLE
Use latest 1.x branch for dart-services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ dart-sdk/
 *.js.map
 
 # Other files.
-*.iml
 pubspec.lock

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ dart-sdk/
 *.js.map
 
 # Other files.
+*.iml
 pubspec.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart-runtime:1.24.2
+FROM google/dart-runtime:1.24.3
 
 # We install memcached and remove the apt-index again to keep the
 # docker image diff small.


### PR DESCRIPTION
Update the Dockerfile and add an intellij exclude to .gitignore.  Doesn't change the version of Dart being used to build for the user.

Currently serving (as non-default) at: https://20180522t122530-dot-dart-services.appspot.com/