### PR TITLE
Explicitly specify types in scheduler and prep for 69.4.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart-runtime:2.0.0-dev.69.3
+FROM google/dart:2.0.0-dev.69.4
 
 # We install memcached and remove the apt-index again to keep the
 # docker image diff small.

--- a/dart-sdk.version
+++ b/dart-sdk.version
@@ -1,3 +1,3 @@
 #
 #Keep this in sync with the version in .travis.yml
-2.0.0-dev.69.3
+2.0.0-dev.69.4

--- a/lib/src/scheduler.dart
+++ b/lib/src/scheduler.dart
@@ -8,12 +8,12 @@ import 'dart:async';
 import 'dart:collection';
 
 class TaskScheduler {
-  Queue<_Task> _taskQueue = new Queue();
+  Queue<_Task<dynamic>> _taskQueue = new Queue();
   bool _isActive = false;
 
   int get queueCount => _taskQueue.length;
 
-  Future _performTask(Task task) {
+  Future<T> _performTask<T>(Task<T> task) {
     if (task.timeoutDuration != null) {
       return task.perform().timeout(task.timeoutDuration);
     } else {
@@ -21,13 +21,13 @@ class TaskScheduler {
     }
   }
 
-  Future schedule(Task task) {
+  Future<T> schedule<T>(Task<T> task) {
     if (!_isActive) {
       _isActive = true;
       return _performTask(task).whenComplete(_next);
     }
-    Completer taskResult = new Completer();
-    _taskQueue.add(new _Task(task, taskResult));
+    Completer taskResult = new Completer<T>();
+    _taskQueue.add(new _Task<T>(task, taskResult));
     return taskResult.future;
   }
 
@@ -43,19 +43,19 @@ class TaskScheduler {
 }
 
 // Internal unit of scheduling.
-class _Task {
-  final Task task;
-  final Completer taskResult;
+class _Task<T> {
+  final Task<T> task;
+  final Completer<T> taskResult;
   _Task(this.task, this.taskResult);
 }
 
 // Public working data structure.
-abstract class Task {
-  Future perform();
+abstract class Task<T> {
+  Future<T> perform();
   Duration timeoutDuration;
 }
 
-class ClosureTask<T> extends Task {
+class ClosureTask<T> extends Task<T> {
   Future<T> Function() _closure;
 
   ClosureTask(this._closure, {Duration timeoutDuration}) {

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -156,12 +156,12 @@ Future testPath(String path, analysis_server.AnalysisServerWrapper wrapper,
 
   for (int i = 0; i < iterations; i++) {
     // Run once for each file without mutation.
-    var averageCompilationTime = 0;
-    var averageAnalysisTime = 0;
-    var averageCompletionTime = 0;
-    var averageDocumentTime = 0;
-    var averageFixesTime = 0;
-    var averageFormatTime = 0;
+    num averageCompilationTime = 0;
+    num averageAnalysisTime = 0;
+    num averageCompletionTime = 0;
+    num averageDocumentTime = 0;
+    num averageFixesTime = 0;
+    num averageFormatTime = 0;
     if (_DUMP_SRC) print(src);
 
     try {
@@ -328,7 +328,7 @@ Future<num> testFormat(String src) async {
   return sw.elapsedMilliseconds;
 }
 
-Future withTimeOut(Future f) {
+Future<T> withTimeOut<T>(Future<T> f) {
   return f.timeout(new Duration(seconds: 30));
 }
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -36,7 +36,7 @@ void serve() {
       Platform.executable, ['bin/server_dev.dart', '--port', '8082']);
 }
 
-final _dockerVersionMatcher = new RegExp(r'^FROM google/dart:(.*)$');
+final _dockerVersionMatcher = new RegExp(r'^FROM google/dart-runtime:(.*)$');
 final _dartSdkVersionMatcher = new RegExp(r'(^\d+[.]\d+[.]\d+.*)');
 @Task('Update the docker and SDK versions')
 void updateDockerVersion() {


### PR DESCRIPTION
Fixes #345.

Explicitly specifying types in the scheduler seems to help the `Future<dynamic>` exceptions in the server, even though I had trouble reproducing them locally.  Fixing the fuzz_driver helped narrow it down though, so adding some type adjustments to that too.