### PR TITLE
Try to reduce flakiness in common_server_test

### DIFF
--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -48,13 +48,6 @@ class AnalysisServerWrapper {
     mainPath = _getPathFromName(kMainDart);
 
     serverScheduler = new TaskScheduler();
-
-    // Write an analysis_options.yaml file with strong mode enabled.
-    // TODO(jcollins-g): this is only required for Travis.  Find out why, then
-    // remove this hack.
-    File optionsFile = new File(_getPathFromName('analysis_options.yaml'));
-    optionsFile.writeAsStringSync(
-        'analyzer:\n  strong-mode: true\n  enablePreviewDart2: $previewDart2\n');
   }
 
   Future init() {

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -77,9 +77,24 @@ void defineTests() {
 
       server = new CommonServer(sdkPath, container, cache, counter);
       await server.init();
+      await server.warmup();
 
       apiServer = new ApiServer(apiPrefix: '/api', prettyPrint: true);
       apiServer.addApi(server);
+
+      {
+        var decodedJson = {};
+        var jsonData = {'source': sampleCodeError};
+        while (decodedJson.isEmpty) {
+          var response =
+              await _sendPostRequest('dartservices/v1/analyze', jsonData);
+          expect(response.status, 200);
+          expect(response.headers['content-type'],
+              'application/json; charset=utf-8');
+          var data = await response.body.first;
+          decodedJson = json.decode(utf8.decode(data));
+        }
+      }
     });
 
     tearDownAll(() {

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -82,6 +82,11 @@ void defineTests() {
       apiServer = new ApiServer(apiPrefix: '/api', prettyPrint: true);
       apiServer.addApi(server);
 
+      // Some piece of initialization doesn't always happen fast enough for
+      // this request to work in time for the test.  So try it here until the
+      // server returns something valid.
+      // TODO(jcollins-g): determine which piece of initialization isn't
+      // happening and deal with that in warmup/init.
       {
         var decodedJson = {};
         var jsonData = {'source': sampleCodeError};

--- a/tool/warmup.dart
+++ b/tool/warmup.dart
@@ -28,16 +28,19 @@ Future main(List<String> args) async {
   print("Target URI\n$uri");
 
   String source =
-      "import 'dart:html'; void main() { var a = 3; var b = a.abs(); }";
+      "import 'dart:html'; void main() { var a = 3; var b = a.abs(); int c = 7;}";
 
   for (int j = 0; j < count; j++) {
     var data = {"offset": 17, "source": source};
+    var dartdocData = {"offset": 84, "source": source};
 
     String postPayload = convert.json.encode(data);
+    String postPayloadDartdoc = convert.json.encode(dartdocData);
 
     await request("complete", postPayload);
     await request("analyze", postPayload);
     await request("compile", postPayload);
+    await request("document", postPayloadDartdoc);
   }
 }
 


### PR DESCRIPTION
This is an attempt to fix intermittent errors following this template:

```
  00:40 +64 ~2 -1: test/analysis_server_test.dart: analysis_server simple_completion
  00:40 +64 ~2 -1: test/common_server_test.dart: CommonServer analyze errors [E]
    Expected: {
                'issues': [
                  {
                    'kind': 'error',
                    'line': 2,
                    'sourceName': 'main.dart',
                    'message': 'Expected to find \';\'.',
                    'hasFixes': true,
                    'charStart': 29,
                    'charLength': 1
                  }
                ],
                'packageImports': []
              }
      Actual: {'issues': [], 'packageImports': []}
       Which: shorter than expected at location ['issues'][0]
  
    package:test                        expect
    test/common_server_test.dart 132:7  defineTests.<fn>.<fn>
    ===== asynchronous gap ===========================
    dart:async                          _AsyncAwaitCompleter.completeError
    test/common_server_test.dart        defineTests.<fn>.<fn>
    ===== asynchronous gap ===========================
    dart:async                          _asyncThenWrapperHelper
    test/common_server_test.dart        defineTests.<fn>.<fn>
  
  00:40 +65 ~2 -1: test/analysis_server_test.dart: analysis_server simple_completion
```