### PR TITLE
Prepare for 69.5, update to latest rpc dev release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart-runtime:2.0.0-dev.69.4
+FROM google/dart-runtime:2.0.0-dev.69.5
 
 # We install memcached and remove the apt-index again to keep the
 # docker image diff small.

--- a/dart-sdk.version
+++ b/dart-sdk.version
@@ -1,3 +1,3 @@
 #
 #Keep this in sync with the version in .travis.yml
-2.0.0-dev.69.4
+2.0.0-dev.69.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   logging: '>=0.9.0 <0.12.0'
   path: ^1.3.0
   shelf: ^0.7.0
-  rpc: '>=0.6.0-dev.0'
+  rpc: '>=0.6.0-dev.1'
   uuid: ^1.0.1
   yaml: ^2.0.0
 


### PR DESCRIPTION
Bringing everything up to speed with the latest 2.0 prerelease and refinements to the rpc package.