### PR TITLE
Use the downloaded SDK for dart2js

### DIFF
--- a/dart-sdk.version
+++ b/dart-sdk.version
@@ -1,3 +1,3 @@
 #
 #Keep this in sync with the version in .travis.yml
-2.1.1-dev.0.0
+2.1.1-dev.1.0

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -77,18 +77,7 @@ class Compiler {
       File mainJs = File(path.join(temp.path, '${kMainDart}.js'));
       File mainSourceMap = File(path.join(temp.path, '${kMainDart}.js.map'));
 
-      // Due to an issue with the VM we need to use the Dart2JS instance from
-      // the image, not from the downloaded SDK
-      // TODO(#327): Use the compiler from the downloaded SDK
-
-      final dartPath = Platform.resolvedExecutable;
-
-      // dart2js is next to dart
-      List<String> dart2JsPathParts = path.split(dartPath)
-        ..removeLast()
-        ..add("dart2js");
-
-      final dart2JSPath = path.joinAll(dart2JsPathParts);
+      final dart2JSPath = path.join(sdkPath, 'bin', 'dart2js');
       _logger.info('About to exec: $dart2JSPath $arguments');
 
       ProcessResult result =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   _discoveryapis_commons: '>=0.1.0 <0.2.0'
   analyzer: ^0.33.1
   analysis_server_lib: ^0.1.2+2
-  appengine: ^0.5.0
+  appengine: ^0.5.1
   archive: ^2.0.0
   args: ^1.4.1
   crypto: ^2.0.0


### PR DESCRIPTION
Fixes #327.

I had some trouble testing this successfully when deploying from my laptop, but my desktop machine it worked the first time.  Services start and respond to compile() requests successfully both locally and (now) on App Engine.