### PR TITLE
Upgrade appengine to 0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/dart:2.1.1-dev.0.0
 
 WORKDIR /app
- ADD tool/dart_run.sh /dart_runtime/
+ADD tool/dart_run.sh /dart_runtime/
 RUN chmod 755 /dart_runtime/dart_run.sh && \
   chown root:root /dart_runtime/dart_run.sh
 ADD pubspec.* /app/
@@ -11,17 +11,16 @@ RUN pub get
 ADD . /app
 RUN pub get --offline
 
-# We install memcached and remove the apt-index again to keep the
+# We install unzip and remove the apt-index again to keep the
 # docker image diff small.
 RUN apt-get update && \
-    apt-get install -y memcached && \
-    apt-get install -y unzip && \
-    cp -a third_party/pkg ../pkg && \
-    rm -rf /var/lib/apt/lists/*
+  apt-get install -y unzip && \
+  cp -a third_party/pkg ../pkg && \
+  rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8080 8181 5858
 
 # Clear out any arguments the base images might have set and ensure we start
-# memcached and wait for it to come up before running the Dart app.
+# the Dart app using custom script enabling debug modes.
 CMD []
-ENTRYPOINT service memcached start && sleep 1 && /bin/bash /dart_runtime/dart_run.sh
+ENTRYPOINT /bin/bash /dart_runtime/dart_run.sh

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   _discoveryapis_commons: ^0.1.8
   analyzer: ^0.34.0
   analysis_server_lib: ^0.1.4
-  appengine: ^0.5.0
+  appengine: ^0.6.0
   archive: ^2.0.0
   args: ^1.4.1
   crypto: ^2.0.0
@@ -19,6 +19,7 @@ dependencies:
   rpc: ^0.6.0-dev.1
   uuid: 2.0.0-rc1
   yaml: ^2.0.0
+  quiver: ^2.0.1
 
 dev_dependencies:
   discoveryapis_generator: ^0.9.9


### PR DESCRIPTION
* Drop support for memcache.
 * Switched to use an in-memory cache instead.
 * Remove `memcached` from the docker container.

It doesn't seem like this application was ever using a shared cache.
Instead each instance had it's own memcached instance running locally, this
makes no sense unless you're planning on migrating to a shared memcached
instance. As this is probably not needed, this commit switches the
application using a minimalistic in-memory cache.

---

**Warning**, I don't have access to a staging environment, so I
don't know if works once deployed. But I built the docker image
locally, and it seemed to start some dart process that complained
about missing `GCLOUD_PROJECT` environment variables.