### PR TITLE
Fix problems preventing coverage from working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ dart-sdk/
 *.js.map
 
 # Other files.
+coverage.json
+lcov.info
 pubspec.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: dart
-
 install:
     - gem install coveralls-lcov
 dart:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,3 @@ dart:
 branches:
   only: [master]
 script: ./tool/travis.sh
-after_success:
-  - coveralls-lcov lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: dart
+
+install:
+    - gem install coveralls-lcov
 dart:
   - stable
   - dev
 branches:
   only: [master]
-script: dart tool/grind.dart buildbot
+script: ./tool/travis.sh
+after_success:
+  - coveralls-lcov lcov.info

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -303,11 +303,12 @@ class AnalysisServerWrapper {
 
   /// Cleanly shutdown the Analysis Server.
   Future shutdown() {
+    // TODO(jcollins-g): calling dispose() sometimes prevents
+    // --pause-isolates-on-exit from working.  Fix.
     return analysisServer.server
         .shutdown()
         .timeout(Duration(seconds: 1))
-        .catchError((e) => null)
-        .whenComplete(() => analysisServer.dispose());
+        .catchError((e) => null);
   }
 
   /// Internal implementation of the completion mechanism.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dev_dependencies:
   discoveryapis_generator: ^0.9.9
   async: '>1.13.3'
   codemirror: ^0.4.0
+  coverage: ^0.12.4
   grinder: ^0.8.0
   test: ^1.3.0
   tuneup: ^0.3.6

--- a/test/all.dart
+++ b/test/all.dart
@@ -4,10 +4,6 @@
 
 library services.all_test;
 
-import 'dart:async';
-
-import 'package:dart_services/src/sdk_manager.dart';
-
 import 'analysis_server_test.dart' as analysis_server_test;
 import 'api_classes_test.dart' as api_classes_test;
 import 'bench_test.dart' as bench_test;
@@ -15,13 +11,12 @@ import 'common_server_test.dart' as common_server_test;
 import 'common_test.dart' as common_test;
 import 'compiler_test.dart' as compiler_test;
 import 'dartpad_server_test.dart' as dartpad_server_test;
+import 'gae_deployed_test.dart' as gae_deployed_test;
 import 'pub_test.dart' as pub_test;
 import 'shelf_cors_test.dart' as shelf_cors_test;
 import 'summarize_test.dart' as summarize_test;
 
-Future main() async {
-  await SdkManager.sdk.init();
-
+void main() {
   analysis_server_test.defineTests();
   api_classes_test.defineTests();
   bench_test.defineTests();
@@ -29,6 +24,7 @@ Future main() async {
   common_test.defineTests();
   compiler_test.defineTests();
   dartpad_server_test.defineTests();
+  gae_deployed_test.defineTests();
   pub_test.defineTests();
   shelf_cors_test.defineTests();
   summarize_test.defineTests();

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -59,7 +59,7 @@ void defineTests() {
     tearDown(() => analysisServer.shutdown());
 
     test('simple_completion', () {
-      //Just after i.
+      // Just after i.
       return analysisServer
           .complete(completionCode, 32)
           .then((CompleteResponse results) {

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -102,9 +102,13 @@ void defineTests() {
       }
     });
 
-    tearDownAll(() {
-      return server.shutdown();
+    // TODO(jcollins-g): calling shutdown sometimes prevents
+    // --pause-isolates-on-exit from working.  Fix.
+    /*
+    tearDownAll(() async {
+      await server.shutdown();
     });
+    */
 
     setUp(() {
       counter.reset();
@@ -116,7 +120,6 @@ void defineTests() {
     tearDown(() {
       log.clearListeners();
     });
-
     test('analyze', () async {
       var jsonData = {'source': sampleCode};
       var response =

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -102,13 +102,9 @@ void defineTests() {
       }
     });
 
-    // TODO(jcollins-g): calling shutdown sometimes prevents
-    // --pause-isolates-on-exit from working.  Fix.
-    /*
     tearDownAll(() async {
       await server.shutdown();
     });
-    */
 
     setUp(() {
       counter.reset();

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -9,8 +9,6 @@ import 'dart:io';
 
 import 'package:grinder/grinder.dart';
 
-Map get _env => Platform.environment;
-
 Future main(List<String> args) => grind(args);
 
 @Task()

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -75,26 +75,7 @@ void deploy() {
 }
 
 @Task()
-void coverage() {
-  if (!_env.containsKey('REPO_TOKEN')) {
-    log("env var 'REPO_TOKEN' not found");
-    return;
-  }
-
-  PubApp coveralls = PubApp.global('dart_coveralls');
-  coveralls.run([
-    'report',
-    '--token',
-    _env['REPO_TOKEN'],
-    '--retry',
-    '2',
-    '--exclude-test-files',
-    'test/all.dart'
-  ]);
-}
-
-@Task()
-@Depends(updateDockerVersion, init, discovery, analyze, test, fuzz, coverage)
+@Depends(updateDockerVersion, init, discovery, analyze, fuzz)
 void buildbot() => null;
 
 @Task('Generate the discovery doc and Dart library from the annotated API')

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+# Fast fail the script on failures.
+set -e
+
+# Run pub get to fetch packages.
+pub get
+
+# Run everything except the unit tests.
+#pub run grinder buildbot
+
+# Gather coverage and upload to Coveralls.
+if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
+  OBS_PORT=9292
+  echo "Collecting coverage on port $OBS_PORT..."
+
+  # Start tests in one VM.
+  dart \
+    --enable-vm-service=$OBS_PORT \
+    --pause-isolates-on-exit \
+    test/all.dart &
+
+  # Run the coverage collector to generate the JSON coverage report.
+  pub run coverage:collect_coverage \
+    --port=$OBS_PORT \
+    --out=coverage.json \
+    --wait-paused \
+    --resume-isolates
+
+  echo "Generating LCOV report..."
+  pub run coverage:format_coverage \
+    --lcov \
+    --in=coverage.json \
+    --out=lcov.info \
+    --packages=.packages \
+    --report-on=lib
+else
+  dart test/all.dart
+fi

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -11,7 +11,7 @@ set -e
 pub get
 
 # Prepare to run unit tests (but do not actually run tests).
-pub run buildbot
+pub run grinder buildbot
 
 # Gather coverage and upload to Coveralls.
 if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -10,6 +10,9 @@ set -e
 # Run pub get to fetch packages.
 pub get
 
+# Fetch sdk.
+pub run init
+
 # Gather coverage and upload to Coveralls.
 if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
   OBS_PORT=9292

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -10,8 +10,8 @@ set -e
 # Run pub get to fetch packages.
 pub get
 
-# Fetch sdk.
-pub run init
+# Prepare to run unit tests (but do not actually run tests).
+pub run buildbot
 
 # Gather coverage and upload to Coveralls.
 if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -10,9 +10,6 @@ set -e
 # Run pub get to fetch packages.
 pub get
 
-# Run everything except the unit tests.
-#pub run grinder buildbot
-
 # Gather coverage and upload to Coveralls.
 if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
   OBS_PORT=9292
@@ -38,6 +35,8 @@ if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
     --out=lcov.info \
     --packages=.packages \
     --report-on=lib
+
+  coveralls-lcov --repo-token="${REPO_TOKEN}" lcov.info
 else
   dart test/all.dart
 fi


### PR DESCRIPTION
Something about shutting down the analysis server prevents --pause-isolates-on-exit from working (dart-lang/sdk#34056).  Work around this by not calling dispose() for the analysis server.

Also change how we run coverage to not double-run tests and show results from the coverage run as well.