### PR TITLE
Move dart-services to VPC network from legacy

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -12,5 +12,8 @@ automatic_scaling:
   cpu_utilization:
     target_utilization: 0.5
 
+network:
+  name: vpc-dart-services
+
 skip_files:
 - ^\.git/.*$

--- a/dart-sdk.version
+++ b/dart-sdk.version
@@ -1,3 +1,3 @@
 #
 #Keep this in sync with the version in .travis.yml
-2.1.1-dev.1.0
+2.1.0


### PR DESCRIPTION
To use cloud memorystore, we have to be on a vpc network instead of the old legacy network format.  Created a VPC network on the cloud project and verified that we can deploy to it and access the API with these settings.