### PR TITLE
Clean up remaining traces of --preview-dart-2

### DIFF
--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -32,7 +32,6 @@ final Duration _ANALYSIS_SERVER_TIMEOUT = Duration(seconds: 35);
 class AnalysisServerWrapper {
   final String sdkPath;
 
-  final bool previewDart2;
   Future _init;
   Directory sourceDirectory;
   String mainPath;
@@ -41,9 +40,8 @@ class AnalysisServerWrapper {
   /// Instance to handle communication with the server.
   AnalysisServer analysisServer;
 
-  AnalysisServerWrapper(this.sdkPath, {this.previewDart2 = false}) {
-    if (previewDart2 == true) ;
-    _logger.info('AnalysisServerWrapper ctor, previewDart2: $previewDart2');
+  AnalysisServerWrapper(this.sdkPath) {
+    _logger.info('AnalysisServerWrapper ctor');
     sourceDirectory = Directory.systemTemp.createTempSync('analysisServer');
     mainPath = _getPathFromName(kMainDart);
 
@@ -61,7 +59,6 @@ class AnalysisServerWrapper {
       }
 
       List<String> serverArgs = <String>[
-        '--${previewDart2 ? '' : 'no-'}preview-dart-2',
         '--dartpad',
         '--client-id=DartPad',
         '--client-version=${_sdkVersion}'

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -74,7 +74,7 @@ void foo(int i) {
 }
 """;
 
-final String samplePreviewDart2OK = """
+final String sampleDart2OK = """
 class Foo {
   String toString() => 'hello';
 }
@@ -84,7 +84,7 @@ void main(List<String> argv) {
 }
 """;
 
-final String samplePreviewDart2Error = """
+final String sampleDart2Error = """
 class Foo {
   final bool isAlwaysNull;
   Foo(this.isAlwaysNull) {}

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -91,7 +91,7 @@ class CommonServer {
   Future init() async {
     pub = enablePackages ? Pub() : Pub.mock();
     compiler = Compiler(sdkPath, pub);
-    analysisServer = AnalysisServerWrapper(sdkPath, previewDart2: true);
+    analysisServer = AnalysisServerWrapper(sdkPath);
 
     await analysisServer.init();
     unawaited(analysisServer.onExit.then((int code) {

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -42,7 +42,6 @@ class Compiler {
   /// Compile the given string and return the resulting [CompilationResults].
   Future<CompilationResults> compile(String input,
       {bool useCheckedMode = true,
-      bool previewDart2 = true,
       bool returnSourceMap = false}) async {
     if (!importsOkForCompile(input)) {
       var failedResults = CompilationResults();
@@ -63,7 +62,6 @@ class Compiler {
         '--suppress-hints',
         '--terse',
       ];
-      if (previewDart2) arguments.add('--preview-dart-2');
       if (useCheckedMode) arguments.add('--enable-asserts');
       if (!returnSourceMap) arguments.add('--no-source-maps');
 

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -162,27 +162,15 @@ void defineTests() {
       expect(issue.kind, 'error');
     });
 
-    test('analyze preview-dart-2', () async {
+    test('analyze dart-2', () async {
       await analysisServer.shutdown();
 
-      analysisServer = AnalysisServerWrapper(sdkPath, previewDart2: true);
+      analysisServer = AnalysisServerWrapper(sdkPath);
       await analysisServer.init();
       AnalysisResults results =
-          await analysisServer.analyze(samplePreviewDart2OK);
+          await analysisServer.analyze(sampleDart2OK);
       expect(results.issues, hasLength(0));
     });
-
-    test('analyze no-preview-dart-2', () async {
-      await analysisServer.shutdown();
-
-      analysisServer = AnalysisServerWrapper(sdkPath, previewDart2: false);
-      await analysisServer.init();
-      AnalysisResults results =
-          await analysisServer.analyze(samplePreviewDart2OK);
-      expect(results.issues, hasLength(1));
-      AnalysisIssue issue = results.issues.first;
-      expect(issue.kind, 'error');
-    }, skip: 'no-preview-dart-2 support needs to be removed entirely');
   });
 }
 

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -53,9 +53,9 @@ void foo(String bar) { print(bar); }
 ''';
 
       CompilationResults normal =
-          await compiler.compile(sampleCodeChecked, previewDart2: false);
+          await compiler.compile(sampleCodeChecked);
       CompilationResults checked = await compiler.compile(sampleCodeChecked,
-          previewDart2: false, useCheckedMode: true);
+          useCheckedMode: true);
 
       expect(normal.getOutput(), equals(checked.getOutput()));
     });
@@ -134,9 +134,9 @@ void main() { print ('foo'); }
       });
     });
 
-    test('errors on previewDart2', () {
+    test('errors for dart 2', () {
       return compiler
-          .compile(samplePreviewDart2Error, previewDart2: true)
+          .compile(sampleDart2Error)
           .then((CompilationResults result) {
         expect(result.problems.length, 1);
       });


### PR DESCRIPTION
We are still passing this flag even though it is no longer necessary.  This PR fixes that.