### PR TITLE
Deprecate all unused RPC interfaces

### DIFF
--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -123,6 +123,7 @@ class CommonServer {
   }
 
   @ApiMethod(method: 'GET', path: 'counter')
+  @deprecated
   Future<CounterResponse> counterGet({String name}) {
     return counter.getTotal(name).then((total) {
       return CounterResponse(total);
@@ -145,6 +146,7 @@ class CommonServer {
       description:
           'Analyze the given Dart source code and return any resulting '
           'analysis errors or warnings.')
+  @deprecated
   Future<AnalysisResults> analyzeMulti(SourcesRequest request) {
     return _analyzeMulti(request.sources);
   }
@@ -155,12 +157,14 @@ class CommonServer {
       description:
           'Summarize the given Dart source code and return any resulting '
           'analysis errors or warnings.')
+  @deprecated
   Future<SummaryText> summarize(SourcesRequest request) {
     return _summarize(request.sources['dart'], request.sources['css'],
         request.sources['html']);
   }
 
   @ApiMethod(method: 'GET', path: 'analyze')
+  @deprecated
   Future<AnalysisResults> analyzeGet({String source}) {
     return _analyze(source);
   }
@@ -176,6 +180,7 @@ class CommonServer {
           returnSourceMap: request.returnSourceMap ?? false);
 
   @ApiMethod(method: 'GET', path: 'compile')
+  @deprecated
   Future<CompileResponse> compileGet({String source}) => _compile(source);
 
   @ApiMethod(
@@ -196,6 +201,7 @@ class CommonServer {
       path: 'completeMulti',
       description:
           'Get the valid code completion results for the given offset.')
+  @deprecated
   Future<CompleteResponse> completeMulti(SourcesRequest request) {
     if (request.location == null) {
       throw BadRequestError('Missing parameter: \'location\'');
@@ -233,6 +239,7 @@ class CommonServer {
       method: 'POST',
       path: 'fixesMulti',
       description: 'Get any quick fixes for the given source code location.')
+  @deprecated
   Future<FixesResponse> fixesMulti(SourcesRequest request) {
     if (request.location.sourceName == null) {
       throw BadRequestError('Missing parameter: \'fullName\'');
@@ -246,6 +253,7 @@ class CommonServer {
   }
 
   @ApiMethod(method: 'GET', path: 'fixes')
+  @deprecated
   Future<FixesResponse> fixesGet({String source, int offset}) {
     if (source == null) {
       throw BadRequestError('Missing parameter: \'source\'');
@@ -268,6 +276,7 @@ class CommonServer {
   }
 
   @ApiMethod(method: 'GET', path: 'format')
+  @deprecated
   Future<FormatResponse> formatGet({String source, int offset}) {
     if (source == null) {
       throw BadRequestError('Missing parameter: \'source\'');
@@ -286,6 +295,7 @@ class CommonServer {
   }
 
   @ApiMethod(method: 'GET', path: 'document')
+  @deprecated
   Future<DocumentResponse> documentGet({String source, int offset}) {
     return _document(source, offset);
   }

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -12,6 +12,7 @@ import 'dart:io' as io;
 import 'dart:math';
 
 import 'package:dart_services/src/analysis_server.dart' as analysis_server;
+import 'package:dart_services/src/api_classes.dart';
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/common_server.dart';
 import 'package:dart_services/src/compiler.dart' as comp;
@@ -233,8 +234,10 @@ Future<num> testAnalysis(
 
   lastOffset = null;
   if (_SERVER_BASED_CALL) {
-    await withTimeOut(server.analyzeGet(source: src));
-    await withTimeOut(server.analyzeGet(source: src));
+    SourceRequest request = SourceRequest();
+    request.source = src;
+    await withTimeOut(server.analyze(request));
+    await withTimeOut(server.analyze(request));
   } else {
     await withTimeOut(analysisServer.analyze(src));
     await withTimeOut(analysisServer.analyze(src));
@@ -249,10 +252,13 @@ Future<num> testCompilation(String src, comp.Compiler compiler) async {
   Stopwatch sw = Stopwatch()..start();
 
   lastOffset = null;
-  if (_SERVER_BASED_CALL)
-    await withTimeOut(server.compileGet(source: src));
-  else
+  if (_SERVER_BASED_CALL) {
+    CompileRequest request = CompileRequest();
+    request.source = src;
+    await withTimeOut(server.compile(request));
+  } else {
     await withTimeOut(compiler.compile(src));
+  }
 
   if (_DUMP_PERF) print("PERF: COMPILATION: ${sw.elapsedMilliseconds}");
   return sw.elapsedMilliseconds;
@@ -268,7 +274,10 @@ Future<num> testDocument(
     if (i % 1000 == 0 && i > 0) print("INC: $i docs completed");
     lastOffset = i;
     if (_SERVER_BASED_CALL) {
-      log(await withTimeOut(server.documentGet(source: src, offset: i)));
+      SourceRequest request = SourceRequest();
+      request.source = src;
+      request.offset = i;
+      log(await withTimeOut(server.document(request)));
     } else {
       log(await withTimeOut(analysisServer.dartdoc(src, i)));
     }
@@ -305,7 +314,10 @@ Future<num> testFixes(
     if (i % 1000 == 0 && i > 0) print("INC: $i fixes");
     lastOffset = i;
     if (_SERVER_BASED_CALL) {
-      await withTimeOut(server.fixesGet(source: src, offset: i));
+      SourceRequest request = SourceRequest();
+      request.source = src;
+      request.offset = i;
+      await withTimeOut(server.fixes(request));
     } else {
       await withTimeOut(wrapper.getFixes(src, i));
     }
@@ -319,7 +331,10 @@ Future<num> testFormat(String src) async {
   Stopwatch sw = Stopwatch()..start();
   int i = 0;
   lastOffset = i;
-  log(await withTimeOut(server.formatGet(source: src, offset: i)));
+  SourceRequest request = SourceRequest();
+  request.source = src;
+  request.offset = i;
+  log(await withTimeOut(server.format(request)));
   return sw.elapsedMilliseconds;
 }
 


### PR DESCRIPTION
Will follow up with something to actually delete these and increment the server version assuming we agree on the list.  I don't intend to deprecate or remove anything that dart-pad currently uses.