### PR TITLE
remove the PubHelper class

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -41,18 +41,11 @@ class Compiler {
 
   /// Compile the given string and return the resulting [CompilationResults].
   Future<CompilationResults> compile(String input,
-      {bool useCheckedMode = true,
-      bool returnSourceMap = false}) async {
+      {bool useCheckedMode = true, bool returnSourceMap = false}) async {
     if (!importsOkForCompile(input)) {
       var failedResults = CompilationResults();
       failedResults.problems.add(CompilationProblem._(BAD_IMPORT_ERROR_MSG));
       return Future.value(failedResults);
-    }
-
-    // ignore: unused_local_variable
-    PubHelper pubHelper;
-    if (pub != null) {
-      pubHelper = await pub.createPubHelperForSource(input);
     }
 
     Directory temp = Directory.systemTemp.createTempSync('dartpad');

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -85,55 +85,6 @@ void defineTests() {
     });
   });
 
-  group('PubHelper', () {
-    test('resolves content', () {
-      final String source = "import 'package:path/path.dart'; void main() { }";
-
-      return pub.createPubHelperForSource(source).then((PubHelper helper) {
-        expect(helper.hasPackages, true);
-        PackageInfo pInfo = helper.getPackage('path');
-        expect(pInfo, isNotNull);
-        expect(pInfo.name, 'path');
-        expect(pInfo.version, isNotNull);
-        return helper
-            .getPackageContentsAsync('package:path/path.dart')
-            .then((contents) {
-          expect(contents, isNotEmpty);
-        });
-      });
-    });
-
-    test('does not resolve', () {
-      final String source =
-          "import moofmilker and package:path/path.dart; void main() { }";
-
-      return pub.createPubHelperForSource(source).then((PubHelper helper) {
-        expect(helper.hasPackages, false);
-      });
-    });
-  });
-
-  group('MockPub', () {
-    test('no-op impls', () {
-      Pub pub = Pub.mock();
-      expect(pub.cacheDir, isNull);
-      pub.flushCache();
-      expect(pub.getVersion(), null);
-
-      return pub
-          .createPubHelperForSource("import 'package:foo/foo.dart';")
-          .then((helper) {
-        expect(helper, isNotNull);
-        return pub.resolvePackages(['foo', 'test']);
-      }).then((packagesInfo) {
-        expect(packagesInfo, isNotNull);
-        return pub.getPackageLibDir(null);
-      }).then((result) {
-        expect(result, isNull);
-      });
-    });
-  });
-
   group('getAllUnsafeImportsFor', () {
     test('null', () {
       expect(getAllUnsafeImportsFor(null), isEmpty);


### PR DESCRIPTION
- remove the `PubHelper` class

We'd never ended up using this class; if we look to support package: imports in the future, we'd use a different mechanism.