### PR TITLE
return a 404 when a request is not found

### DIFF
--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -128,7 +128,7 @@ class GaeServer {
       });
     } else {
       request.response
-        ..statusCode = io.HttpStatus.internalServerError
+        ..statusCode = io.HttpStatus.notFound
         ..close();
     }
   }


### PR DESCRIPTION
- when a requested resource is not found, return a 404 error (instead of a 500, internal server error)

@RedBrogdon @domesticmouse 