### PR TITLE
add initial support for compiling with DDC

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -782,9 +782,6 @@ class CompileRequest {
   /// The Dart source.
   core.String source;
 
-  /// Ignored. (server always assumes checked mode/asserts enabled)
-  core.bool useCheckedMode;
-
   CompileRequest();
 
   CompileRequest.fromJson(core.Map _json) {
@@ -793,9 +790,6 @@ class CompileRequest {
     }
     if (_json.containsKey("source")) {
       source = _json["source"];
-    }
-    if (_json.containsKey("useCheckedMode")) {
-      useCheckedMode = _json["useCheckedMode"];
     }
   }
 
@@ -807,9 +801,6 @@ class CompileRequest {
     }
     if (source != null) {
       _json["source"] = source;
-    }
-    if (useCheckedMode != null) {
-      _json["useCheckedMode"] = useCheckedMode;
     }
     return _json;
   }

--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -133,7 +133,8 @@ class DartservicesApi {
     return _response.then((data) => new AnalysisResults.fromJson(data));
   }
 
-  /// Compile the given Dart source code and return the resulting JavaScript.
+  /// Compile the given Dart source code and return the resulting JavaScript;
+  /// this uses the dart2js compiler.
   ///
   /// [request] - The metadata request object.
   ///
@@ -167,6 +168,43 @@ class DartservicesApi {
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
     return _response.then((data) => new CompileResponse.fromJson(data));
+  }
+
+  /// Compile the given Dart source code and return the resulting JavaScript;
+  /// this uses the DDC compiler.
+  ///
+  /// [request] - The metadata request object.
+  ///
+  /// Request parameters:
+  ///
+  /// Completes with a [CompileDDCResponse].
+  ///
+  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
+  /// error.
+  ///
+  /// If the used [http.Client] completes with an error when making a REST call,
+  /// this method will complete with the same error.
+  async.Future<CompileDDCResponse> compileDDC(CompileRequest request) {
+    var _url = null;
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
+    var _uploadMedia = null;
+    var _uploadOptions = null;
+    var _downloadOptions = commons.DownloadOptions.Metadata;
+    var _body = null;
+
+    if (request != null) {
+      _body = convert.json.encode((request).toJson());
+    }
+
+    _url = 'compileDDC';
+
+    var _response = _requester.request(_url, "POST",
+        body: _body,
+        queryParams: _queryParams,
+        uploadOptions: _uploadOptions,
+        uploadMedia: _uploadMedia,
+        downloadOptions: _downloadOptions);
+    return _response.then((data) => new CompileDDCResponse.fromJson(data));
   }
 
   /// Request parameters:
@@ -770,6 +808,35 @@ class CandidateFix {
     }
     if (message != null) {
       _json["message"] = message;
+    }
+    return _json;
+  }
+}
+
+class CompileDDCResponse {
+  core.String result;
+  core.List<core.String> staticScriptUris;
+
+  CompileDDCResponse();
+
+  CompileDDCResponse.fromJson(core.Map _json) {
+    if (_json.containsKey("result")) {
+      result = _json["result"];
+    }
+    if (_json.containsKey("staticScriptUris")) {
+      staticScriptUris =
+          (_json["staticScriptUris"] as core.List).cast<core.String>();
+    }
+  }
+
+  core.Map<core.String, core.Object> toJson() {
+    final core.Map<core.String, core.Object> _json =
+        new core.Map<core.String, core.Object>();
+    if (result != null) {
+      _json["result"] = result;
+    }
+    if (staticScriptUris != null) {
+      _json["staticScriptUris"] = staticScriptUris;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "e7bd82adc33b47356475f8de3a60bca8d4a66a1c",
+ "etag": "b14ca576dd86324239a5e2240e369506138b5066",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -150,6 +150,21 @@
     },
     "sourceMap": {
      "type": "string"
+    }
+   }
+  },
+  "CompileDDCResponse": {
+   "id": "CompileDDCResponse",
+   "type": "object",
+   "properties": {
+    "result": {
+     "type": "string"
+    },
+    "staticScriptUris": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
     }
    }
   },
@@ -363,7 +378,7 @@
    "id": "CommonServer.compile",
    "path": "compile",
    "httpMethod": "POST",
-   "description": "Compile the given Dart source code and return the resulting JavaScript.",
+   "description": "Compile the given Dart source code and return the resulting JavaScript; this uses the dart2js compiler.",
    "parameters": {},
    "parameterOrder": [],
    "request": {
@@ -388,6 +403,20 @@
    "parameterOrder": [],
    "response": {
     "$ref": "CompileResponse"
+   }
+  },
+  "compileDDC": {
+   "id": "CommonServer.compileDDC",
+   "path": "compileDDC",
+   "httpMethod": "POST",
+   "description": "Compile the given Dart source code and return the resulting JavaScript; this uses the DDC compiler.",
+   "parameters": {},
+   "parameterOrder": [],
+   "request": {
+    "$ref": "CompileRequest"
+   },
+   "response": {
+    "$ref": "CompileDDCResponse"
    }
   },
   "complete": {

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "8409030dfd68aba3d66fe912fea8f7a7e8fd5f2a",
+ "etag": "e7bd82adc33b47356475f8de3a60bca8d4a66a1c",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -134,10 +134,6 @@
      "type": "string",
      "description": "The Dart source.",
      "required": true
-    },
-    "useCheckedMode": {
-     "type": "boolean",
-     "description": "Ignored. (server always assumes checked mode/asserts enabled)"
     },
     "returnSourceMap": {
      "type": "boolean",

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -81,8 +81,7 @@ class EndpointsServer {
 
   static Future<String> generateDiscovery(
       String sdkPath, String serverUrl) async {
-    var commonServer =
-        CommonServer(sdkPath, _ServerContainer(), _Cache());
+    var commonServer = CommonServer(sdkPath, _ServerContainer(), _Cache());
     await commonServer.init();
     var apiServer = ApiServer(apiPrefix: '/api', prettyPrint: true)
       ..addApi(commonServer);
@@ -120,8 +119,7 @@ class EndpointsServer {
 
   EndpointsServer._(String sdkPath, this.port) {
     discoveryEnabled = false;
-    commonServer =
-        CommonServer(sdkPath, _ServerContainer(), _Cache());
+    commonServer = CommonServer(sdkPath, _ServerContainer(), _Cache());
     commonServer.init();
     apiServer = ApiServer(apiPrefix: '/api', prettyPrint: true)
       ..addApi(commonServer);
@@ -189,10 +187,13 @@ class _ServerContainer implements ServerContainer {
 class _Cache implements ServerCache {
   @override
   Future<String> get(String key) => Future.value(null);
+
   @override
   Future set(String key, String value, {Duration expiration}) => Future.value();
+
   @override
   Future remove(String key) => Future.value();
+
   @override
   Future<void> shutdown() => Future.value();
 }

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -90,12 +90,6 @@ class CompileRequest {
 
   @ApiProperty(
       description:
-          'Ignored. (server always assumes checked mode/asserts enabled)')
-  @deprecated
-  bool useCheckedMode;
-
-  @ApiProperty(
-      description:
           'Return the Dart to JS source map; optional (defaults to false).')
   bool returnSourceMap;
 }

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -81,6 +81,7 @@ class Location {
   int offset;
 
   Location();
+
   Location.from(this.sourceName, this.offset);
 }
 
@@ -99,6 +100,18 @@ class CompileResponse {
   final String sourceMap;
 
   CompileResponse(this.result, [this.sourceMap]);
+}
+
+class CompileDDCRequest {
+  @ApiProperty(required: true, description: 'The Dart source.')
+  String source;
+}
+
+class CompileDDCResponse {
+  final String result;
+  final List<String> staticScriptUris;
+
+  CompileDDCResponse(this.result, this.staticScriptUris);
 }
 
 class CounterRequest {
@@ -165,6 +178,7 @@ class ProblemAndFixes {
   final int length;
 
   ProblemAndFixes() : this.fromList([]);
+
   ProblemAndFixes.fromList(
       [this.fixes, this.problemMessage, this.offset, this.length]);
 }
@@ -175,6 +189,7 @@ class CandidateFix {
   final List<SourceEdit> edits;
 
   CandidateFix() : this.fromEdits();
+
   CandidateFix.fromEdits([this.message, this.edits]);
 }
 
@@ -197,6 +212,7 @@ class SourceEdit {
   final String replacement;
 
   SourceEdit() : this.fromChanges();
+
   SourceEdit.fromChanges([this.offset, this.length, this.replacement]);
 
   String applyTo(String target) {

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -636,7 +636,6 @@ class CommonServer {
         int ms = watch.elapsedMilliseconds;
         log.info('PERF: Compiled ${lineCount} lines of Dart into '
             '${outputSize}kb of JavaScript in ${ms}ms.');
-        // todo: include script uris
         String cachedResult = JsonEncoder().convert({
           'compiledJS': results.compiledJS,
           'staticScriptUris': results.staticScriptUris,

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -570,7 +570,7 @@ class CommonServer {
       );
     }
 
-    log.info("CACHE: MISS, forced: $suppressCache");
+    log.info("CACHE: MISS for compileDart2js, forced: $suppressCache");
     Stopwatch watch = Stopwatch()..start();
 
     return compiler
@@ -581,7 +581,7 @@ class CommonServer {
         int outputSize = (results.compiledJS.length + 512) ~/ 1024;
         int ms = watch.elapsedMilliseconds;
         log.info('PERF: Compiled ${lineCount} lines of Dart into '
-            '${outputSize}kb of JavaScript in ${ms}ms.');
+            '${outputSize}kb of JavaScript in ${ms}ms using dart2js.');
         String sourceMap = returnSourceMap ? results.sourceMap : null;
 
         String cachedResult = JsonEncoder().convert({
@@ -597,7 +597,7 @@ class CommonServer {
         throw BadRequestError(errors);
       }
     }).catchError((e, st) {
-      log.severe('Error during compile: ${e}\n${st}');
+      log.severe('Error during compile (dart2js): ${e}\n${st}');
       throw e;
     });
   }
@@ -614,6 +614,8 @@ class CommonServer {
     bool suppressCache = trimSrc.endsWith("/** Supress-Memcache **/") ||
         trimSrc.endsWith("/** Suppress-Memcache **/");
 
+    // TODO(devoncarew): Include the version of referenced libraries in the
+    // keys.
     String memCacheKey = "%%COMPILE_DDC:v0:source:$sourceHash";
 
     String result = await checkCache(memCacheKey);
@@ -626,7 +628,7 @@ class CommonServer {
       );
     }
 
-    log.info("CACHE: MISS, forced: $suppressCache");
+    log.info("CACHE: MISS for compileDDC, forced: $suppressCache");
     Stopwatch watch = Stopwatch()..start();
 
     return compiler.compileDDC(source).then((DDCCompilationResults results) {
@@ -635,7 +637,7 @@ class CommonServer {
         int outputSize = (results.compiledJS.length + 512) ~/ 1024;
         int ms = watch.elapsedMilliseconds;
         log.info('PERF: Compiled ${lineCount} lines of Dart into '
-            '${outputSize}kb of JavaScript in ${ms}ms.');
+            '${outputSize}kb of JavaScript in ${ms}ms using DDC.');
         String cachedResult = JsonEncoder().convert({
           'compiledJS': results.compiledJS,
           'staticScriptUris': results.staticScriptUris,
@@ -650,7 +652,7 @@ class CommonServer {
         throw BadRequestError(errors);
       }
     }).catchError((e, st) {
-      log.severe('Error during compile: ${e}\n${st}');
+      log.severe('Error during compile (DDC): ${e}\n${st}');
       throw e;
     });
   }

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -71,7 +71,7 @@ class Compiler {
       File mainJs = File(path.join(temp.path, '${kMainDart}.js'));
       File mainSourceMap = File(path.join(temp.path, '${kMainDart}.js.map'));
 
-      final dart2JSPath = path.join(sdkPath, 'bin', 'dart2js');
+      final String dart2JSPath = path.join(sdkPath, 'bin', 'dart2js');
       _logger.info('About to exec: $dart2JSPath $arguments');
 
       ProcessResult result =
@@ -125,11 +125,11 @@ class Compiler {
 
       File mainJs = File(path.join(temp.path, '${kMainDart}.js'));
 
-      final dart2JSPath = path.join(sdkPath, 'bin', 'dartdevc');
-      _logger.info('About to exec: $dart2JSPath $arguments');
+      final String dartdevcPath = path.join(sdkPath, 'bin', 'dartdevc');
+      _logger.info('About to exec: $dartdevcPath $arguments');
 
       final ProcessResult result =
-          Process.runSync(dart2JSPath, arguments, workingDirectory: temp.path);
+          Process.runSync(dartdevcPath, arguments, workingDirectory: temp.path);
 
       if (result.exitCode != 0) {
         return DDCCompilationResults.failed([

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -12,8 +12,8 @@ import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/common_server.dart';
 import 'package:logging/logging.dart';
 import 'package:pedantic/pedantic.dart';
-import 'package:synchronized/synchronized.dart';
 import 'package:rpc/rpc.dart';
+import 'package:synchronized/synchronized.dart';
 import 'package:test/test.dart';
 
 String quickFixesCode = r'''
@@ -84,12 +84,13 @@ void defineTests() {
     // since they talk to the same redis instances.
     Lock singleTestOnly = Lock();
 
-    // Prevent cases where we might try to reenter addStream for either
-    // stdout or stderr (which will throw a BadState).
+    // Prevent cases where we might try to reenter addStream for either  stdout
+    // or stderr (which will throw a BadState).
     Lock singleStreamOnly = Lock();
 
     Future<Process> startRedisProcessAndDrainIO(int port) async {
-      Process newRedisProcess = await Process.start('redis-server', ['--port', port.toString()]);
+      Process newRedisProcess =
+          await Process.start('redis-server', ['--port', port.toString()]);
       unawaited(singleStreamOnly.synchronized(() async {
         await stdout.addStream(newRedisProcess.stdout);
       }));
@@ -140,20 +141,25 @@ void defineTests() {
     test('Verify values expire', () async {
       await singleTestOnly.synchronized(() async {
         logMessages = [];
-        await redisCache.set('expiringkey', 'expiringValue', expiration: Duration(milliseconds: 1));
+        await redisCache.set('expiringkey', 'expiringValue',
+            expiration: Duration(milliseconds: 1));
         await Future.delayed(Duration(milliseconds: 100));
         await expectLater(await redisCache.get('expiringkey'), isNull);
         expect(logMessages, isEmpty);
       });
     });
 
-    test('Verify two caches with different versions give different results for keys', () async {
+    test(
+        'Verify two caches with different versions give different results for keys',
+        () async {
       await singleTestOnly.synchronized(() async {
         logMessages = [];
         await redisCache.set('differentVersionKey', 'value1');
         await redisCacheAlt.set('differentVersionKey', 'value2');
-        await expectLater(await redisCache.get('differentVersionKey'), 'value1');
-        await expectLater(await redisCacheAlt.get('differentVersionKey'), 'value2');
+        await expectLater(
+            await redisCache.get('differentVersionKey'), 'value1');
+        await expectLater(
+            await redisCacheAlt.get('differentVersionKey'), 'value2');
         expect(logMessages, isEmpty);
       });
     });
@@ -161,35 +167,42 @@ void defineTests() {
     test('Verify disconnected cache logs errors and returns nulls', () async {
       await singleTestOnly.synchronized(() async {
         logMessages = [];
-        RedisCache redisCacheBroken = RedisCache('redis://localhost:9502', 'cversion');
+        RedisCache redisCacheBroken =
+            RedisCache('redis://localhost:9502', 'cversion');
         try {
           await redisCacheBroken.set('aKey', 'value');
           await expectLater(await redisCacheBroken.get('aKey'), isNull);
           await redisCacheBroken.remove('aKey');
-          expect(logMessages.join('\n'), stringContainsInOrder([
-            'no cache available when setting key cversion+aKey',
-            'no cache available when getting key cversion+aKey',
-            'no cache available when removing key cversion+aKey',
-          ]));
+          expect(
+              logMessages.join('\n'),
+              stringContainsInOrder([
+                'no cache available when setting key cversion+aKey',
+                'no cache available when getting key cversion+aKey',
+                'no cache available when removing key cversion+aKey',
+              ]));
         } finally {
           await redisCacheBroken.shutdown();
         }
       });
     });
 
-    test('Verify cache that starts out disconnected retries and works (slow)', () async {
+    test('Verify cache that starts out disconnected retries and works (slow)',
+        () async {
       await singleTestOnly.synchronized(() async {
         logMessages = [];
-        RedisCache redisCacheRepairable = RedisCache('redis://localhost:9503', 'cversion');
+        RedisCache redisCacheRepairable =
+            RedisCache('redis://localhost:9503', 'cversion');
         try {
           // Wait for a retry message.
-          while(logMessages.length < 2) {
-            await(Future.delayed(Duration(milliseconds: 50)));
+          while (logMessages.length < 2) {
+            await (Future.delayed(Duration(milliseconds: 50)));
           }
-          expect(logMessages.join('\n'), stringContainsInOrder([
-            'reconnecting to redis://localhost:9503...\n',
-            'Unable to connect to redis server, reconnecting in',
-          ]));
+          expect(
+              logMessages.join('\n'),
+              stringContainsInOrder([
+                'reconnecting to redis://localhost:9503...\n',
+                'Unable to connect to redis server, reconnecting in',
+              ]));
 
           // Start a redis server.
           redisAltProcess = await startRedisProcessAndDrainIO(9503);
@@ -203,7 +216,9 @@ void defineTests() {
       });
     });
 
-    test('Verify that cache that stops responding temporarily times out and can recover', () async {
+    test(
+        'Verify that cache that stops responding temporarily times out and can recover',
+        () async {
       await singleTestOnly.synchronized(() async {
         logMessages = [];
         await redisCache.set('beforeStop', 'truth');
@@ -215,20 +230,25 @@ void defineTests() {
         expect(beforeStop, isNull);
         await redisCache.connected;
         await expectLater(await redisCache.get('beforeStop'), equals('truth'));
-        expect(logMessages.join('\n'), stringContainsInOrder([
-          'timeout on get operation for key aversion+beforeStop',
-          '(aversion): reconnecting',
-          '(aversion): Connected to redis server',
-        ]));
+        expect(
+            logMessages.join('\n'),
+            stringContainsInOrder([
+              'timeout on get operation for key aversion+beforeStop',
+              '(aversion): reconnecting',
+              '(aversion): Connected to redis server',
+            ]));
       });
     }, onPlatform: {'windows': Skip('Windows does not have sigstop/sigcont')});
 
-    test('Verify cache that starts out connected but breaks retries until reconnection (slow)', () async {
+    test(
+        'Verify cache that starts out connected but breaks retries until reconnection (slow)',
+        () async {
       await singleTestOnly.synchronized(() async {
         logMessages = [];
 
         redisAltProcess = await startRedisProcessAndDrainIO(9504);
-        RedisCache redisCacheHealing = RedisCache('redis://localhost:9504', 'cversion');
+        RedisCache redisCacheHealing =
+            RedisCache('redis://localhost:9504', 'cversion');
         try {
           await redisCacheHealing.connected;
           await redisCacheHealing.set('missingKey', 'value');
@@ -237,7 +257,7 @@ void defineTests() {
           await redisAltProcess.exitCode;
           redisAltProcess = null;
 
-          // Try to talk to the cache and get an error.  Wait for the disconnect
+          // Try to talk to the cache and get an error. Wait for the disconnect
           // to be recognized.
           await expectLater(await redisCacheHealing.get('missingKey'), isNull);
           await redisCacheHealing.disconnected;
@@ -245,11 +265,13 @@ void defineTests() {
           // Start the server and verify we connect appropriately.
           redisAltProcess = await startRedisProcessAndDrainIO(9504);
           await redisCacheHealing.connected;
-          expect(logMessages.join('\n'), stringContainsInOrder([
-            'Connected to redis server',
-            'connection terminated with error SocketException',
-            'reconnecting to redis://localhost:9504',
-          ]));
+          expect(
+              logMessages.join('\n'),
+              stringContainsInOrder([
+                'Connected to redis server',
+                'connection terminated with error SocketException',
+                'reconnecting to redis://localhost:9504',
+              ]));
           expect(logMessages.last, contains('Connected to redis server'));
         } finally {
           await redisCacheHealing.shutdown();
@@ -265,14 +287,13 @@ void defineTests() {
 
       server = CommonServer(sdkPath, container, cache);
       await server.init();
-      await server.warmup();
 
       apiServer = ApiServer(apiPrefix: '/api', prettyPrint: true);
       apiServer.addApi(server);
 
-      // Some piece of initialization doesn't always happen fast enough for
-      // this request to work in time for the test.  So try it here until the
-      // server returns something valid.
+      // Some piece of initialization doesn't always happen fast enough for this
+      // request to work in time for the test. So try it here until the server
+      // returns something valid.
       // TODO(jcollins-g): determine which piece of initialization isn't
       // happening and deal with that in warmup/init.
       {
@@ -303,6 +324,7 @@ void defineTests() {
     tearDown(() {
       log.clearListeners();
     });
+
     test('analyze', () async {
       var jsonData = {'source': sampleCode};
       var response =
@@ -369,6 +391,15 @@ void defineTests() {
       var response =
           await _sendPostRequest('dartservices/v1/compile', jsonData);
       expect(response.status, 400);
+    });
+
+    test('compileDDC', () async {
+      var jsonData = {'source': sampleCode};
+      var response =
+          await _sendPostRequest('dartservices/v1/compileDDC', jsonData);
+      expect(response.status, 200);
+      var data = await response.body.first;
+      expect(json.decode(utf8.decode(data)), isNotEmpty);
     });
 
     test('complete', () async {
@@ -529,10 +560,13 @@ class MockContainer implements ServerContainer {
 class MockCache implements ServerCache {
   @override
   Future<String> get(String key) => Future.value(null);
+
   @override
   Future set(String key, String value, {Duration expiration}) => Future.value();
+
   @override
   Future remove(String key) => Future.value();
+
   @override
   Future<void> shutdown() => Future.value();
 }

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -84,7 +84,7 @@ void defineTests() {
     // since they talk to the same redis instances.
     Lock singleTestOnly = Lock();
 
-    // Prevent cases where we might try to reenter addStream for either  stdout
+    // Prevent cases where we might try to reenter addStream for either stdout
     // or stderr (which will throw a BadState).
     Lock singleStreamOnly = Lock();
 

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -21,8 +21,8 @@ void defineTests() {
     test('simple', () {
       return compiler.compile(sampleCode).then((CompilationResults result) {
         expect(result.success, true);
-        expect(result.getOutput(), isNotEmpty);
-        expect(result.getSourceMap(), isEmpty);
+        expect(result.compiledJS, isNotEmpty);
+        expect(result.sourceMap, isEmpty);
       });
     });
 
@@ -31,8 +31,8 @@ void defineTests() {
           .compile(sampleCode, returnSourceMap: true)
           .then((CompilationResults result) {
         expect(result.success, true);
-        expect(result.getOutput(), isNotEmpty);
-        expect(result.getSourceMap(), isNotEmpty);
+        expect(result.compiledJS, isNotEmpty);
+        expect(result.sourceMap, isNotEmpty);
       });
     });
 
@@ -42,22 +42,8 @@ void defineTests() {
           .then((CompilationResults result) {
         expect(compiler.version, isNotNull);
         expect(compiler.version, startsWith('2.'));
-        expect(result.getSourceMap(), isNotEmpty);
+        expect(result.sourceMap, isNotEmpty);
       });
-    });
-
-    test('verify asserts always enabled', () async {
-      final String sampleCodeChecked = '''
-main() { foo(1); }
-void foo(String bar) { print(bar); }
-''';
-
-      CompilationResults normal =
-          await compiler.compile(sampleCodeChecked);
-      CompilationResults checked = await compiler.compile(sampleCodeChecked,
-          useCheckedMode: true);
-
-      expect(normal.getOutput(), equals(checked.getOutput()));
     });
 
     test('simple web', () {

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -22,7 +22,17 @@ void defineTests() {
       return compiler.compile(sampleCode).then((CompilationResults result) {
         expect(result.success, true);
         expect(result.compiledJS, isNotEmpty);
-        expect(result.sourceMap, isEmpty);
+        expect(result.sourceMap, isNull);
+      });
+    });
+
+    test('simple ddc', () {
+      return compiler
+          .compileDDC(sampleCode)
+          .then((DDCCompilationResults result) {
+        expect(result.success, true);
+        expect(result.compiledJS, isNotEmpty);
+        expect(result.staticScriptUris, hasLength(2));
       });
     });
 
@@ -32,6 +42,7 @@ void defineTests() {
           .then((CompilationResults result) {
         expect(result.success, true);
         expect(result.compiledJS, isNotEmpty);
+        expect(result.sourceMap, isNotNull);
         expect(result.sourceMap, isNotEmpty);
       });
     });
@@ -42,6 +53,7 @@ void defineTests() {
           .then((CompilationResults result) {
         expect(compiler.version, isNotNull);
         expect(compiler.version, startsWith('2.'));
+        expect(result.sourceMap, isNotNull);
         expect(result.sourceMap, isNotEmpty);
       });
     });

--- a/test/gae_deployed_test.dart
+++ b/test/gae_deployed_test.dart
@@ -16,6 +16,7 @@ void defineTests({bool skip = true}) {
   group('gae deployed tests', () {
     test('analyze end point', analyzeTest, skip: skip);
     test('compile end point', compileTest, skip: skip);
+    test('compileDDC end point', compileDDCTest, skip: skip);
   });
 }
 
@@ -36,6 +37,21 @@ void analyzeTest() {
 
 void compileTest() {
   final String url = '${serverUrl}/api/compile';
+  Map headers = {'Content-Type': 'text/plain; charset=UTF-8'};
+
+  expect(
+      http
+          .post(url, headers: headers, body: common.sampleCodeWeb)
+          .then((response) {
+        expect(response.statusCode, 200);
+        expect(true, response.body.length > 100);
+        return true;
+      }),
+      completion(equals(true)));
+}
+
+void compileDDCTest() {
+  final String url = '${serverUrl}/api/compileDDC';
   Map headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 
   expect(


### PR DESCRIPTION
- add a `compileDDC()` restful call
- remove an unsued `checked` param to the `compile()` request
- add tests for the compile DDC call
- regenerate the `doc/generated/dartservices.dart` / dartservices.json files
- refactor some of the request / response objects to improve the API a bit
- fixes https://github.com/dart-lang/dart-pad/issues/951

a follow up to https://github.com/dart-lang/dart-services/pull/375

(some unintentional diffs due to formatting existing files)

@RedBrogdon @domesticmouse 