### PR TITLE
some fixes to the DDC support

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -814,29 +814,28 @@ class CandidateFix {
 }
 
 class CompileDDCResponse {
+  core.String modulesBaseUrl;
   core.String result;
-  core.List<core.String> staticScriptUris;
 
   CompileDDCResponse();
 
   CompileDDCResponse.fromJson(core.Map _json) {
+    if (_json.containsKey("modulesBaseUrl")) {
+      modulesBaseUrl = _json["modulesBaseUrl"];
+    }
     if (_json.containsKey("result")) {
       result = _json["result"];
-    }
-    if (_json.containsKey("staticScriptUris")) {
-      staticScriptUris =
-          (_json["staticScriptUris"] as core.List).cast<core.String>();
     }
   }
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
         new core.Map<core.String, core.Object>();
+    if (modulesBaseUrl != null) {
+      _json["modulesBaseUrl"] = modulesBaseUrl;
+    }
     if (result != null) {
       _json["result"] = result;
-    }
-    if (staticScriptUris != null) {
-      _json["staticScriptUris"] = staticScriptUris;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "b14ca576dd86324239a5e2240e369506138b5066",
+ "etag": "dae0b714d4f8d5bd3d0926341491efd8ef566973",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -160,11 +160,8 @@
     "result": {
      "type": "string"
     },
-    "staticScriptUris": {
-     "type": "array",
-     "items": {
-      "type": "string"
-     }
+    "modulesBaseUrl": {
+     "type": "string"
     }
    }
   },

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -251,7 +251,7 @@ class AnalysisServerWrapper {
       issues.sort();
 
       // Calculate the imports.
-      Set<String> packageImports = {};
+      Set<String> packageImports = <String>{};
       for (String source in sources.values) {
         packageImports.addAll(
             filterSafePackagesFromImports(getAllUnsafeImportsFor(source)));
@@ -380,7 +380,7 @@ class AnalysisServerWrapper {
   Future<api.CompleteResponse> warmup({bool useHtml = false}) =>
       complete(useHtml ? _WARMUP_SRC_HTML : _WARMUP_SRC, 10);
 
-  final Set<String> _overlayPaths = {};
+  final Set<String> _overlayPaths = <String>{};
 
   Future<void> _loadSources(Map<String, String> sources) async {
     if (_overlayPaths.isNotEmpty) {
@@ -465,7 +465,8 @@ class AnalysisServerWrapper {
     return completer;
   }
 
-  final Map<String, List<AnalysisError>> _errors = <String, List<AnalysisError>>{};
+  final Map<String, List<AnalysisError>> _errors =
+      <String, List<AnalysisError>>{};
 
   void listenForErrors() {
     analysisServer.analysis.onErrors.listen((AnalysisErrors result) {

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -113,9 +113,9 @@ class CompileDDCRequest {
 
 class CompileDDCResponse {
   final String result;
-  final List<String> staticScriptUris;
+  final String modulesBaseUrl;
 
-  CompileDDCResponse(this.result, this.staticScriptUris);
+  CompileDDCResponse(this.result, this.modulesBaseUrl);
 }
 
 class CounterRequest {

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -634,12 +634,12 @@ class CommonServer {
             '${outputSize}kb of JavaScript in ${ms}ms using DDC.');
         String cachedResult = JsonEncoder().convert(<String, dynamic>{
           'compiledJS': results.compiledJS,
-          'staticScriptUris': results.staticScriptUris,
+          'modulesBaseUrl': results.modulesBaseUrl,
         });
         // Don't block on cache set.
         unawaited(setCache(memCacheKey, cachedResult));
 
-        return CompileDDCResponse(results.compiledJS, results.staticScriptUris);
+        return CompileDDCResponse(results.compiledJS, results.modulesBaseUrl);
       } else {
         List<CompilationProblem> problems = results.problems;
         String errors = problems.map(_printCompileProblem).join('\n');

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -118,6 +118,7 @@ class Compiler {
         '--modules=amd',
       ];
       arguments.addAll(<String>['-o', '$kMainDart.js']);
+      arguments.add('--single-out-file');
       arguments.addAll(<String>['--module-name', 'dartpad_main']);
       arguments.add(kMainDart);
 
@@ -138,22 +139,10 @@ class Compiler {
           CompilationProblem._(result.stdout),
         ]);
       } else {
-        String compiledJS = mainJs.readAsStringSync();
-
-        // Here, we post-process the DDC output to insert an AMD module name.
-        // In the future, we'd want support from DDC to create modules with a
-        // name (https://github.com/dart-lang/sdk/issues/36423).
-        if (compiledJS.contains('define([')) {
-          compiledJS = compiledJS.replaceFirst(
-            'define([',
-            'define("dartpad_main", [',
-          );
-        }
-
         // TODO(devoncarew): The hard-coded URL below will be replaced with
         // something based on the sdk version.
         final DDCCompilationResults results = DDCCompilationResults(
-          compiledJS: compiledJS,
+          compiledJS: mainJs.readAsStringSync(),
           modulesBaseUrl:
               'https://storage.cloud.google.com/compilation_artifacts/',
         );

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -34,7 +34,7 @@ void defineTests() {
         expect(result.compiledJS, isNotEmpty);
         expect(result.modulesBaseUrl, isNotEmpty);
 
-        expect(result.compiledJS, contains('define("dartpad_main", ['));
+        expect(result.compiledJS, contains("define('dartpad_main', ["));
       });
     });
 

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -32,7 +32,9 @@ void defineTests() {
           .then((DDCCompilationResults result) {
         expect(result.success, true);
         expect(result.compiledJS, isNotEmpty);
-        expect(result.staticScriptUris, hasLength(2));
+        expect(result.modulesBaseUrl, isNotEmpty);
+
+        expect(result.compiledJS, contains('define("dartpad_main", ['));
       });
     });
 


### PR DESCRIPTION
- create well-formed AMD modules (they need to be named for us to be able to load them in the front end)
- change the compileDDC endpoint API - instead of the list of all the artifacts, we just need to know the directory containing them. In the future, the directory would be different for the Dart sdk version we're compiling for

@RedBrogdon @domesticmouse 