### PR TITLE
Remove lint always_specify_types

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,7 +9,6 @@ analyzer:
 linter:
   rules:
     - always_declare_return_types
-    - always_specify_types
     - annotate_overrides
     - avoid_empty_else
     - avoid_function_literals_in_foreach_calls

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 library services.bench;
 
 import 'dart:async';

--- a/example/apitest.dart
+++ b/example/apitest.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 library services_server.apitest;
 
 import 'dart:html';

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -256,8 +256,8 @@ class AnalysisServerWrapper {
       // Calculate the imports.
       Set<String> packageImports = <String>{};
       for (String source in sources.values) {
-        packageImports.addAll(
-            filterSafePackagesFromImports(getAllImportsFor(source)));
+        packageImports
+            .addAll(filterSafePackagesFromImports(getAllImportsFor(source)));
       }
 
       return api.AnalysisResults(

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 
 /// A simple, properties file based configuration class.
-/// 
+///
 /// We expect an (optional) file in the root of the directory, names 'config.properties'.
 class Config {
   static Config _singleton;

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 library services.analyzer_server_test;
 
 import 'package:dart_services/src/analysis_server.dart';

--- a/test/api_classes_test.dart
+++ b/test/api_classes_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 library services.api_classes_test;
 
 import 'package:dart_services/src/api_classes.dart';

--- a/test/bench_test.dart
+++ b/test/bench_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 library services.bench_test;
 
 import 'dart:async';

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 library services.common_server_test;
 
 import 'dart:async';

--- a/test/dartpad_server_test.dart
+++ b/test/dartpad_server_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 library services.dartpad_server_test;
 
 import 'dart:async';

--- a/test/flutter_web_test.dart
+++ b/test/flutter_web_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 import 'dart:io';
 
 import 'package:dart_services/src/common.dart';

--- a/test/gae_deployed_test.dart
+++ b/test/gae_deployed_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 library gaeDeployed_test;
 
 import 'package:dart_services/src/common.dart' as common;

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 import 'package:dart_services/src/pub.dart';
 import 'package:test/test.dart';
 

--- a/test/shelf_cors_test.dart
+++ b/test/shelf_cors_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -6,8 +6,6 @@
 /// test variations. This should be run over all of the co19 tests in the SDK
 /// prior to each deployment of the server.
 
-// ignore_for_file: always_specify_types
-
 library services.fuzz_driver;
 
 import 'dart:async';

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
 library services.grind;
 
 import 'dart:async';

--- a/tool/load_driver.dart
+++ b/tool/load_driver.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 import 'dart:async';
 
 import 'package:http/http.dart' as http;

--- a/tool/warmup.dart
+++ b/tool/warmup.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: always_specify_types
-
 import 'dart:async';
 import 'dart:convert' as convert;
 


### PR DESCRIPTION
This lint is not appropriate for repos under `dart-lang`. Only the
flutter SDK should use this lint.

For repositories under `dart-lang` we should always follow
https://www.dartlang.org/guides/language/effective-dart

Also run `dartfmt`.