### PR TITLE
update to use dartdevc as a persistent worker

### DIFF
--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -8,32 +8,51 @@ library services.bench;
 
 import 'dart:async';
 
+import 'package:logging/logging.dart';
+
 import 'package:dart_services/src/analysis_server.dart';
 import 'package:dart_services/src/bench.dart';
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/compiler.dart';
 import 'package:dart_services/src/flutter_web.dart';
 
-void main(List<String> args) {
+void main(List<String> args) async {
   final bool json = args.contains('--json');
 
   final BenchmarkHarness harness = BenchmarkHarness(asJson: json);
 
   final FlutterWebManager flutterWebManager = FlutterWebManager(sdkPath);
+  await flutterWebManager.warmup();
+  var compiler = Compiler(sdkPath, flutterWebManager);
+
+  Logger.root.level = Level.WARNING;
+  Logger.root.onRecord.listen((LogRecord record) {
+    print(record);
+    if (record.stackTrace != null) print(record.stackTrace);
+  });
 
   final List<Benchmark> benchmarks = [
     AnalyzerBenchmark('hello', sampleCode, flutterWebManager),
     AnalyzerBenchmark('hellohtml', sampleCodeWeb, flutterWebManager),
     AnalyzerBenchmark('sunflower', _sunflower, flutterWebManager),
+    AnalyzerBenchmark('spinning_square', _spinningSquare, flutterWebManager),
     AnalysisServerBenchmark('hello', sampleCode, flutterWebManager),
     AnalysisServerBenchmark('hellohtml', sampleCodeWeb, flutterWebManager),
     AnalysisServerBenchmark('sunflower', _sunflower, flutterWebManager),
-    Dart2jsBenchmark('hello', sampleCode, flutterWebManager),
-    Dart2jsBenchmark('hellohtml', sampleCodeWeb, flutterWebManager),
-    Dart2jsBenchmark('sunflower', _sunflower, flutterWebManager),
+    AnalysisServerBenchmark(
+        'spinning_square', _spinningSquare, flutterWebManager),
+    Dart2jsBenchmark('hello', sampleCode, compiler),
+    Dart2jsBenchmark('hellohtml', sampleCodeWeb, compiler),
+    Dart2jsBenchmark('sunflower', _sunflower, compiler),
+    Dart2jsBenchmark('spinning_square', _spinningSquare, compiler),
+    DevCompilerBenchmark('hello', sampleCode, compiler),
+    DevCompilerBenchmark('hellohtml', sampleCodeWeb, compiler),
+    DevCompilerBenchmark('sunflower', _sunflower, compiler),
+    DevCompilerBenchmark('spinning_square', _spinningSquare, compiler),
   ];
 
-  harness.benchmark(benchmarks);
+  await harness.benchmark(benchmarks);
+  await compiler.dispose();
 }
 
 class AnalyzerBenchmark extends Benchmark {
@@ -60,14 +79,27 @@ class Dart2jsBenchmark extends Benchmark {
   final String source;
   final Compiler compiler;
 
-  Dart2jsBenchmark(
-      String name, this.source, FlutterWebManager flutterWebManager)
-      : compiler = Compiler(sdkPath, flutterWebManager),
-        super('dart2js.$name');
+  Dart2jsBenchmark(String name, this.source, this.compiler)
+      : super('dart2js.$name');
 
   @override
   Future perform() {
     return compiler.compile(source).then((CompilationResults result) {
+      if (!result.success) throw result;
+    });
+  }
+}
+
+class DevCompilerBenchmark extends Benchmark {
+  final String source;
+  final Compiler compiler;
+
+  DevCompilerBenchmark(String name, this.source, this.compiler)
+      : super('dartdevc.$name');
+
+  @override
+  Future perform() {
+    return compiler.compileDDC(source).then((DDCCompilationResults result) {
       if (!result.success) throw result;
     });
   }
@@ -106,7 +138,7 @@ class Sunflower {
   static const String ORANGE = "orange";
   static const SEED_RADIUS = 2;
   static const SCALE_FACTOR = 4;
-  static const TAU = math.PI * 2;
+  static const TAU = math.pi * 2;
   static const MAX_D = 300;
 
   CanvasRenderingContext2D ctx;
@@ -155,5 +187,57 @@ class Sunflower {
     ctx.closePath();
     ctx.stroke();
   }
+}
+''';
+
+final _spinningSquare = '''
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'package:flutter_web/material.dart';
+import 'package:flutter_web_ui/ui.dart' as ui;
+
+class SpinningSquare extends StatefulWidget {
+  @override
+  _SpinningSquareState createState() => new _SpinningSquareState();
+}
+
+class _SpinningSquareState extends State<SpinningSquare>
+    with SingleTickerProviderStateMixin {
+  AnimationController _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    // We use 3600 milliseconds instead of 1800 milliseconds because 0.0 -> 1.0
+    // represents an entire turn of the square whereas in the other examples
+    // we used 0.0 -> math.pi, which is only half a turn.
+    _animation = new AnimationController(
+      duration: const Duration(milliseconds: 3600),
+      vsync: this,
+    )..repeat();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new RotationTransition(
+        turns: _animation,
+        child: new Container(
+          width: 200.0,
+          height: 200.0,
+          color: const Color(0xFF00FF00),
+        ));
+  }
+
+  @override
+  void dispose() {
+    _animation.dispose();
+    super.dispose();
+  }
+}
+
+main() async {
+  await ui.webOnlyInitializePlatform();
+  runApp(new Center(child: new SpinningSquare()));
 }
 ''';

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -22,8 +22,8 @@ void main(List<String> args) async {
   final BenchmarkHarness harness = BenchmarkHarness(asJson: json);
 
   final FlutterWebManager flutterWebManager = FlutterWebManager(sdkPath);
-  // Fetches the flutter web summary files etc from google cloud storage.
-  await flutterWebManager.warmup();
+  await flutterWebManager.initFlutterWeb();
+
   var compiler = Compiler(sdkPath, flutterWebManager);
 
   Logger.root.level = Level.WARNING;

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -22,6 +22,7 @@ void main(List<String> args) async {
   final BenchmarkHarness harness = BenchmarkHarness(asJson: json);
 
   final FlutterWebManager flutterWebManager = FlutterWebManager(sdkPath);
+  // Fetches the flutter web summary files etc from google cloud storage.
   await flutterWebManager.warmup();
   var compiler = Compiler(sdkPath, flutterWebManager);
 

--- a/lib/src/bench.dart
+++ b/lib/src/bench.dart
@@ -124,7 +124,7 @@ class BenchMarkResult {
   double averageMilliseconds() => (microseconds / iteration) / 1000.0;
 
   @override
-  String toString() => '[${benchmark.name.padRight(20)}: '
+  String toString() => '[${benchmark.name.padRight(26)}: '
       '${averageMilliseconds().toStringAsFixed(3).padLeft(8)}ms]';
 }
 

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -312,6 +312,7 @@ class CommonServer {
   Future<dynamic> shutdown() {
     return Future.wait(<Future<dynamic>>[
       analysisServer.shutdown(),
+      compiler.dispose(),
       Future<dynamic>.sync(cache.shutdown)
     ]);
   }

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -28,8 +28,10 @@ class Compiler {
   String _sdkVersion;
 
   Compiler(this.sdkPath, this.flutterWebManager)
-      : _ddcDriver = BazelWorkerDriver(() => Process.start(
-            path.join(sdkPath, 'bin', 'dartdevc'), ['--persistent_worker'])) {
+      : _ddcDriver = BazelWorkerDriver(
+            () => Process.start(path.join(sdkPath, 'bin', 'dartdevc'),
+                <String>['--persistent_worker']),
+            maxWorkers: 1) {
     _sdkVersion = File('dart-sdk.version').readAsStringSync().trim();
   }
 

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -8,6 +8,7 @@ library services.compiler;
 import 'dart:async';
 import 'dart:io';
 
+import 'package:bazel_worker/driver.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 
@@ -23,9 +24,12 @@ class Compiler {
   final String sdkPath;
   final FlutterWebManager flutterWebManager;
 
+  final BazelWorkerDriver _ddcDriver;
   String _sdkVersion;
 
-  Compiler(this.sdkPath, this.flutterWebManager) {
+  Compiler(this.sdkPath, this.flutterWebManager)
+      : _ddcDriver = BazelWorkerDriver(() => Process.start(
+            path.join(sdkPath, 'bin', 'dartdevc'), ['--persistent_worker'])) {
     _sdkVersion = File('dart-sdk.version').readAsStringSync().trim();
   }
 
@@ -130,26 +134,25 @@ class Compiler {
         arguments.addAll(<String>['-s', flutterWebManager.summaryFilePath]);
       }
 
-      arguments.addAll(<String>['-o', '$kMainDart.js']);
-      arguments.add('--single-out-file');
-      arguments.addAll(<String>['--module-name', 'dartpad_main']);
-      arguments.add(kMainDart);
-
       String compileTarget = path.join(temp.path, kMainDart);
       File mainDart = File(compileTarget);
       mainDart.writeAsStringSync(input);
 
+      arguments.addAll(<String>['-o', path.join(temp.path, '$kMainDart.js')]);
+      arguments.add('--single-out-file');
+      arguments.addAll(<String>['--module-name', 'dartpad_main']);
+      arguments.add(compileTarget);
+
       File mainJs = File(path.join(temp.path, '$kMainDart.js'));
 
-      final String dartdevcPath = path.join(sdkPath, 'bin', 'dartdevc');
-      _logger.info('About to exec: $dartdevcPath $arguments');
+      _logger.info('About to exec dartdevc with:  $arguments');
 
-      final ProcessResult result =
-          Process.runSync(dartdevcPath, arguments, workingDirectory: temp.path);
+      final WorkResponse response =
+          await _ddcDriver.doWork(WorkRequest()..arguments.addAll(arguments));
 
-      if (result.exitCode != 0) {
+      if (response.exitCode != 0) {
         return DDCCompilationResults.failed(<CompilationProblem>[
-          CompilationProblem._(result.stdout),
+          CompilationProblem._(response.output),
         ]);
       } else {
         final DDCCompilationResults results = DDCCompilationResults(
@@ -167,6 +170,8 @@ class Compiler {
       _logger.info('temp folder removed: ${temp.path}');
     }
   }
+
+  Future<void> dispose() => _ddcDriver.terminateWorkers();
 }
 
 /// The result of a dart2js compile.
@@ -185,6 +190,11 @@ class CompilationResults {
 
   /// This is true if there were no errors.
   bool get success => problems.isEmpty;
+
+  @override
+  String toString() => success
+      ? 'CompilationResults: Success'
+      : 'Compilation errors: ${problems.join('\n')}';
 }
 
 /// The result of a DDC compile.
@@ -204,6 +214,10 @@ class DDCCompilationResults {
 
   /// This is true if there were no errors.
   bool get success => problems.isEmpty;
+  @override
+  String toString() => success
+      ? 'CompilationResults: Success'
+      : 'Compilation errors: ${problems.join('\n')}';
 }
 
 /// An issue associated with [CompilationResults].

--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -52,11 +52,7 @@ $_samplePackageName:lib/
   }
 
   Future<void> warmup() async {
-    try {
-      await initFlutterWeb();
-    } catch (_) {
-      // ignore any exception here
-    }
+    await initFlutterWeb();
   }
 
   Future<void> initFlutterWeb() async {

--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -52,7 +52,11 @@ $_samplePackageName:lib/
   }
 
   Future<void> warmup() async {
-    await initFlutterWeb();
+    try {
+      await initFlutterWeb();
+    } catch (e, s) {
+      _logger.warning('Error initializing flutter web', e, s);
+    }
   }
 
   Future<void> initFlutterWeb() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   analysis_server_lib: ^0.1.4
   appengine: ^0.6.0
   args: ^1.4.1
+  bazel_worker: ^0.1.14
   crypto: ^2.0.0
   dartis: ^0.3.0
   http: ^0.12.0

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -16,10 +16,14 @@ void defineTests() {
   FlutterWebManager flutterWebManager;
 
   group('compiler', () {
-    setUp(() async {
+    setUpAll(() async {
       flutterWebManager = FlutterWebManager(sdkPath);
 
       compiler = Compiler(sdkPath, flutterWebManager);
+    });
+
+    tearDownAll(() async {
+      await compiler.dispose();
     });
 
     test('simple', () {


### PR DESCRIPTION
Closes https://github.com/dart-lang/dart-pad/issues/1003

cc @devoncarew @RedBrogdon @domesticmouse not sure what combination of you would like to review this :).

This uses the bazel_worker package to run a pool of persistent dartdevc tasks and schedule jobs between them. Currently it is using the default number of workers (4), but that is easily tweakable (and I don't know what makes the most sense for dartpad - if it only handles one request at a time then just 1 would be needed although it doesn't hurt to have it higher technically - it would only spin up 1 in that case still). 

Note that I did not switch to using kernel - that would be a bit more involved and doesn't really seem necessary although we could get additional wins from it.

I did a few other cleanup things as well, feel free to push back on any of those, I will leave specific comments as to why I changed them though.

I added general dev compiler benchmarks and a spinning square benchmark for all modes and got the following results for ddc:

## Before
```
[dartdevc.hello            :  181.118ms]
[dartdevc.hellohtml        :  219.658ms]
[dartdevc.sunflower        :  241.977ms]
[dartdevc.spinning_square  :  251.619ms]
```

## After

```
[dartdevc.hello            :   19.113ms]
[dartdevc.hellohtml        :   32.594ms]
[dartdevc.sunflower        :   46.399ms]
[dartdevc.spinning_square  :   41.897ms]
```