### PR TITLE
Eliminating implicit casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,8 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
+  strong-mode:
+    implicit-casts: false
   exclude:
     - 'dart-sdk/**'
     - 'third_party/**'

--- a/example/apitest.dart
+++ b/example/apitest.dart
@@ -47,7 +47,7 @@ void _setupClients() {
 void setupSummary() {
   CodeMirror editor = createEditor(querySelector('#summarySection .editor'));
   Element output = querySelector('#summarySection .output');
-  ButtonElement button = querySelector('#summarySection button');
+  ButtonElement button = querySelector('#summarySection button') as ButtonElement;
   button.onClick.listen((e) {
     _setupClients();
     services.SourcesRequest input = services.SourcesRequest();
@@ -64,7 +64,7 @@ void setupSummary() {
 
 void setupIdRetrieval() {
   Element output = querySelector('#idSection .output');
-  ButtonElement button = querySelector('#idSection button');
+  ButtonElement button = querySelector('#idSection button') as ButtonElement;
   button.onClick.listen((e) {
     Stopwatch sw = Stopwatch()..start();
     _dartpadSupportApi.getUnusedMappingId().then((results) {
@@ -77,7 +77,7 @@ void setupGistStore() {
   CodeMirror editor = createEditor(querySelector('#storeSection .editor'),
       defaultText: 'Internal ID');
   Element output = querySelector('#storeSection .output');
-  ButtonElement button = querySelector('#storeSection button');
+  ButtonElement button = querySelector('#storeSection button') as ButtonElement;
   button.onClick.listen((e) {
     String editorText = editor.getDoc().getValue();
     support.GistToInternalIdMapping saveObject =
@@ -95,7 +95,7 @@ void setupGistRetrieval() {
   CodeMirror editor = createEditor(querySelector('#gistSection .editor'),
       defaultText: 'Internal ID');
   Element output = querySelector('#gistSection .output');
-  ButtonElement button = querySelector('#gistSection button');
+  ButtonElement button = querySelector('#gistSection button') as ButtonElement;
   button.onClick.listen((e) {
     String editorText = editor.getDoc().getValue();
     Stopwatch sw = Stopwatch()..start();
@@ -108,7 +108,7 @@ void setupGistRetrieval() {
 void setupAnalyze() {
   CodeMirror editor = createEditor(querySelector('#analyzeSection .editor'));
   Element output = querySelector('#analyzeSection .output');
-  ButtonElement button = querySelector('#analyzeSection button');
+  ButtonElement button = querySelector('#analyzeSection button') as ButtonElement;
   button.onClick.listen((e) {
     _setupClients();
     services.SourceRequest srcRequest = services.SourceRequest()
@@ -123,7 +123,7 @@ void setupAnalyze() {
 void setupCompile() {
   CodeMirror editor = createEditor(querySelector('#compileSection .editor'));
   Element output = querySelector('#compileSection .output');
-  ButtonElement button = querySelector('#compileSection button');
+  ButtonElement button = querySelector('#compileSection button') as ButtonElement;
   button.onClick.listen((e) {
     String source = editor.getDoc().getValue();
 
@@ -142,7 +142,7 @@ void setupComplete() {
   CodeMirror editor = createEditor(querySelector('#completeSection .editor'));
   Element output = querySelector('#completeSection .output');
   Element offsetElement = querySelector('#completeSection .offset');
-  ButtonElement button = querySelector('#completeSection button');
+  ButtonElement button = querySelector('#completeSection button') as ButtonElement;
   button.onClick.listen((e) {
     var sourceRequest = _getSourceRequest(editor);
     Stopwatch sw = Stopwatch()..start();
@@ -160,7 +160,7 @@ void setupDocument() {
   CodeMirror editor = createEditor(querySelector('#documentSection .editor'));
   Element output = querySelector('#documentSection .output');
   Element offsetElement = querySelector('#documentSection .offset');
-  ButtonElement button = querySelector('#documentSection button');
+  ButtonElement button = querySelector('#documentSection button') as ButtonElement;
   button.onClick.listen((e) {
     var sourceRequest = _getSourceRequest(editor);
     Stopwatch sw = Stopwatch()..start();
@@ -178,7 +178,7 @@ void setupFixes() {
   CodeMirror editor = createEditor(querySelector('#fixesSection .editor'));
   Element output = querySelector('#fixesSection .output');
   Element offsetElement = querySelector('#fixesSection .offset');
-  ButtonElement button = querySelector('#fixesSection button');
+  ButtonElement button = querySelector('#fixesSection button') as ButtonElement;
   button.onClick.listen((e) {
     var sourceRequest = _getSourceRequest(editor);
     Stopwatch sw = Stopwatch()..start();
@@ -195,7 +195,7 @@ void setupFixes() {
 
 void setupVersion() {
   Element output = querySelector('#versionSection .output');
-  ButtonElement button = querySelector('#versionSection button');
+  ButtonElement button = querySelector('#versionSection button') as ButtonElement;
   button.onClick.listen((e) {
     Stopwatch sw = Stopwatch()..start();
     servicesApi.version().then((results) {
@@ -207,7 +207,7 @@ void setupVersion() {
 void setupExport() {
   CodeMirror editor = createEditor(querySelector('#exportSection .editor'));
   Element output = querySelector('#exportSection .output');
-  ButtonElement button = querySelector('#exportSection button');
+  ButtonElement button = querySelector('#exportSection button') as ButtonElement;
   button.onClick.listen((e) {
     support.PadSaveObject saveObject = support.PadSaveObject();
     saveObject.dart = editor.getDoc().getValue();
@@ -222,7 +222,7 @@ void setupRetrieve() {
   Element output = querySelector('#retrieveSection .output');
   CodeMirror editor =
       createEditor(querySelector('#retrieveSection .editor'), defaultText: '');
-  ButtonElement button = querySelector('#retrieveSection button');
+  ButtonElement button = querySelector('#retrieveSection button') as ButtonElement;
   button.onClick.listen((e) {
     String uuid = editor.getDoc().getValue();
 

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -31,7 +31,7 @@ void main(List<String> args) {
   parser.addOption('server-url', defaultsTo: 'http://localhost');
 
   ArgResults result = parser.parse(args);
-  num port = int.tryParse(result['port']);
+  num port = int.tryParse(result['port'] as String);
   if (port == null) {
     stdout.writeln(
         'Could not parse port value "${result['port']}" into a number.');
@@ -45,9 +45,9 @@ void main(List<String> args) {
     exit(0);
   }
 
-  if (result['discovery']) {
-    String serverUrl = result['server-url'];
-    if (result['relay']) {
+  if (result['discovery'] as bool) {
+    String serverUrl = result['server-url'] as String;
+    if (result['relay'] as bool) {
       EndpointsServer.generateRelayDiscovery(sdk, serverUrl).then(printExit);
     } else {
       EndpointsServer.generateDiscovery(sdk, serverUrl).then(printExit);
@@ -61,7 +61,7 @@ void main(List<String> args) {
     if (record.stackTrace != null) print(record.stackTrace);
   });
 
-  EndpointsServer.serve(sdk, port).then((EndpointsServer server) {
+  EndpointsServer.serve(sdk, port.toInt()).then((EndpointsServer server) {
     _logger.info('Listening on port ${server.port}');
   });
 }

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -31,7 +31,7 @@ void main(List<String> args) {
   parser.addOption('server-url', defaultsTo: 'http://localhost');
 
   ArgResults result = parser.parse(args);
-  num port = int.tryParse(result['port'] as String);
+  int port = int.tryParse(result['port'] as String);
   if (port == null) {
     stdout.writeln(
         'Could not parse port value "${result['port']}" into a number.');
@@ -61,7 +61,7 @@ void main(List<String> args) {
     if (record.stackTrace != null) print(record.stackTrace);
   });
 
-  EndpointsServer.serve(sdk, port.toInt()).then((EndpointsServer server) {
+  EndpointsServer.serve(sdk, port).then((EndpointsServer server) {
     _logger.info('Listening on port ${server.port}');
   });
 }

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -153,13 +153,13 @@ class CompleteResponse {
   static List<Map<String, String>> _convert(List<Map<dynamic, dynamic>> list) {
     return list.map<Map<String, String>>((Map<dynamic, dynamic> m) {
       Map<String, String> newMap = <String, String>{};
-      for (String key in m.keys) {
+      for (dynamic key in m.keys) {
         dynamic data = m[key];
         // TODO: Properly support Lists, Maps (this is a hack).
         if (data is Map || data is List) {
           data = json.encode(data);
         }
-        newMap[key] = '$data';
+        newMap[key.toString()] = '$data';
       }
       return newMap;
     }).toList();

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -153,7 +153,7 @@ class CompleteResponse {
   static List<Map<String, String>> _convert(List<Map<dynamic, dynamic>> list) {
     return list.map<Map<String, String>>((Map<dynamic, dynamic> m) {
       Map<String, String> newMap = <String, String>{};
-      for (dynamic key in m.keys) {
+      for (var key in m.keys.cast<String>()) {
         dynamic data = m[key];
         // TODO: Properly support Lists, Maps (this is a hack).
         if (data is Map || data is List) {

--- a/lib/src/bench.dart
+++ b/lib/src/bench.dart
@@ -132,6 +132,7 @@ bool isCheckedMode() {
   try {
     String result = 'foo';
     result = '${result}bar';
+    // ignore: invalid_assignment
     result = _intVal;
     return false;
   } catch (e) {

--- a/lib/src/bench.dart
+++ b/lib/src/bench.dart
@@ -34,12 +34,6 @@ class BenchmarkHarness {
   BenchmarkHarness({this.asJson, this.logger = print});
 
   Future<void> benchmark(List<Benchmark> benchmarks) async {
-    if (isCheckedMode()) {
-      logger(
-          'WARNING: You are running in checked mode. Benchmarks should be run in unchecked,\n'
-          'non-debug mode. See also www.dartlang.org/articles/benchmarking.\n');
-    }
-
     log('Running ${benchmarks.length} benchmarks.');
     log('');
 
@@ -127,17 +121,3 @@ class BenchMarkResult {
   String toString() => '[${benchmark.name.padRight(26)}: '
       '${averageMilliseconds().toStringAsFixed(3).padLeft(8)}ms]';
 }
-
-bool isCheckedMode() {
-  try {
-    String result = 'foo';
-    result = '${result}bar';
-    // ignore: invalid_assignment
-    result = _intVal;
-    return false;
-  } catch (e) {
-    return true;
-  }
-}
-
-dynamic get _intVal => 1 + 2;

--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -571,8 +571,8 @@ class CommonServer {
       log.info('CACHE: Cache hit for compile');
       dynamic resultObj = JsonDecoder().convert(result);
       return CompileResponse(
-        resultObj['compiledJS'],
-        returnSourceMap ? resultObj['sourceMap'] : null,
+        resultObj['compiledJS'] as String,
+        returnSourceMap ? resultObj['sourceMap'] as String : null,
       );
     }
 
@@ -627,8 +627,8 @@ class CommonServer {
       log.info('CACHE: Cache hit for compileDDC');
       dynamic resultObj = JsonDecoder().convert(result);
       return CompileDDCResponse(
-        resultObj['compiledJS'],
-        resultObj['staticScriptUris'],
+        resultObj['compiledJS'] as String,
+        resultObj['staticScriptUris'] as String,
       );
     }
 

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -85,7 +85,7 @@ class Compiler {
       if (result.exitCode != 0) {
         final CompilationResults results =
             CompilationResults(problems: <CompilationProblem>[
-          CompilationProblem._(result.stdout),
+          CompilationProblem._(result.stdout as String),
         ]);
         return results;
       } else {
@@ -149,7 +149,7 @@ class Compiler {
 
       if (result.exitCode != 0) {
         return DDCCompilationResults.failed(<CompilationProblem>[
-          CompilationProblem._(result.stdout),
+          CompilationProblem._(result.stdout as String),
         ]);
       } else {
         final DDCCompilationResults results = DDCCompilationResults(

--- a/lib/src/dartpad_support_server.dart
+++ b/lib/src/dartpad_support_server.dart
@@ -29,7 +29,7 @@ class FileRelayServer {
       mirrors.reflect(obj).type.reflectedType.toString();
 
   String getClass(dynamic obj) =>
-      mirrors.MirrorSystem.getName(mirrors.reflectClass(obj).simpleName);
+      mirrors.MirrorSystem.getName(mirrors.reflectClass(obj as Type).simpleName);
 
   FileRelayServer({this.test = false}) {
     hierarchicalLoggingEnabled = true;
@@ -62,7 +62,7 @@ class FileRelayServer {
     return Future<List<dynamic>>.value(result);
   }
 
-  Future<void> _databaseCommit({List<dynamic> inserts, List<dynamic> deletes}) {
+  Future<void> _databaseCommit({List<db.Model> inserts, List<db.Key> deletes}) {
     if (test) {
       if (inserts != null) {
         for (dynamic insertObject in inserts) {
@@ -89,7 +89,7 @@ class FileRelayServer {
     _GaePadSaveObject record = _GaePadSaveObject.fromDSO(data);
     String randomUuid = uuid_tools.Uuid().v4();
     record.uuid = '${_computeSHA1(record)}-$randomUuid';
-    _databaseCommit(inserts: <dynamic>[record]).catchError((dynamic e) {
+    _databaseCommit(inserts: <db.Model>[record]).catchError((dynamic e) {
       _logger.severe('Error while recording export $e');
       throw e;
     });
@@ -109,9 +109,9 @@ class FileRelayServer {
           .severe('Export with UUID ${uuidContainer.uuid} could not be found.');
       throw BadRequestError('Nothing of correct uuid could be found.');
     }
-    _GaePadSaveObject record = result.first;
+    _GaePadSaveObject record = result.first as _GaePadSaveObject;
     if (!test) {
-      unawaited(_databaseCommit(deletes: <dynamic>[record.key])
+      unawaited(_databaseCommit(deletes: <db.Key>[record.key])
           .catchError((dynamic e) {
         _logger.severe('Error while deleting export $e');
         throw (e);
@@ -153,7 +153,7 @@ class FileRelayServer {
     } else {
       _GistMapping entry = _GistMapping.fromMap(map);
       unawaited(
-          _databaseCommit(inserts: <dynamic>[entry]).catchError((dynamic e) {
+          _databaseCommit(inserts: <db.Model>[entry]).catchError((dynamic e) {
         _logger.severe(
             'Error while recording mapping with Id ${map.gistId}. Error $e');
         throw e;
@@ -174,7 +174,7 @@ class FileRelayServer {
       _logger.severe('Missing mapping for Id $id.');
       throw BadRequestError('Missing mapping for Id $id');
     } else {
-      _GistMapping entry = result.first;
+      _GistMapping entry = result.first as _GistMapping;
       _logger.info('Mapping with ID $id retrieved.');
       return Future<UuidContainer>.value(UuidContainer.fromUuid(entry.gistId));
     }

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -10,39 +10,39 @@ import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/flutter_web.dart';
 import 'package:test/test.dart';
 
-String completionCode = r'''
+const completionCode = r'''
 void main() {
   int i = 0;
   i.
 }
 ''';
 
-String completionFilterCode = r'''
+const completionFilterCode = r'''
 void main() {
   pr
 }
 ''';
 
-String quickFixesCode = r'''
+const quickFixesCode = r'''
 void main() {
   int i = 0
 }
 ''';
 
-String badFormatCode = r'''
+const badFormatCode = r'''
 void main()
 {
 int i = 0;
 }
 ''';
 
-String formattedCode = r'''
+const formattedCode = r'''
 void main() {
   int i = 0;
 }
 ''';
 
-String formatWithIssues = '''
+const formatWithIssues = '''
 void main() { foo() }
 ''';
 

--- a/test/api_classes_test.dart
+++ b/test/api_classes_test.dart
@@ -12,9 +12,9 @@ void main() => defineTests();
 void defineTests() {
   group('AnalysisIssue', () {
     test('toMap', () {
-      AnalysisIssue issue =
+      final issue =
           AnalysisIssue.fromIssue('error', 1, 'not found', charStart: 123);
-      Map m = issue.toMap();
+      final m = issue.toMap();
       expect(m['kind'], 'error');
       expect(m['line'], 1);
       expect(m['message'], isNotNull);

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -17,27 +17,27 @@ import 'package:rpc/rpc.dart';
 import 'package:synchronized/synchronized.dart';
 import 'package:test/test.dart';
 
-String quickFixesCode = r'''
+const quickFixesCode = r'''
 import 'dart:async';
 void main() {
   int i = 0;
 }
 ''';
 
-String preFormattedCode = r'''
+const preFormattedCode = r'''
 void main()
 {
 int i = 0;
 }
 ''';
 
-String postFormattedCode = r'''
+const postFormattedCode = r'''
 void main() {
   int i = 0;
 }
 ''';
 
-String formatBadCode = r'''
+const formatBadCode = r'''
 void main()
 {
   print('foo')

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -311,7 +311,7 @@ void defineTests() {
           expect(response.headers['content-type'],
               'application/json; charset=utf-8');
           var data = await response.body.first;
-          decodedJson = json.decode(utf8.decode(data));
+          decodedJson = json.decode(utf8.decode(data)) as Map<dynamic,dynamic>;
         }
       }
     });

--- a/test/common_test.dart
+++ b/test/common_test.dart
@@ -14,13 +14,13 @@ void main() => defineTests();
 void defineTests() {
   group('Lines', () {
     test('empty string', () {
-      Lines lines = Lines('');
+      final lines = Lines('');
       expect(lines.getLineForOffset(0), 0);
       expect(lines.getLineForOffset(1), 0);
     });
 
     test('getLineForOffset', () {
-      Lines lines = Lines('one\ntwo\nthree');
+      final lines = Lines('one\ntwo\nthree');
       expect(lines.getLineForOffset(0), 0);
       expect(lines.getLineForOffset(1), 0);
       expect(lines.getLineForOffset(2), 0);

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -95,7 +95,7 @@ void defineTests() {
     });
 
     test('good import', () {
-      final String code = '''
+      const code = '''
 import 'dart:html';
 
 void main() {
@@ -110,7 +110,7 @@ void main() {
     });
 
     test('bad import - local', () {
-      final String code = '''
+      const code = '''
 import 'foo.dart';
 void main() { missingMethod ('foo'); }
 ''';
@@ -121,7 +121,7 @@ void main() { missingMethod ('foo'); }
     });
 
     test('bad import - http', () {
-      final String code = '''
+      const code = '''
 import 'http://example.com';
 void main() { missingMethod ('foo'); }
 ''';
@@ -137,7 +137,7 @@ void main() { missingMethod ('foo'); }
     });
 
     test('transitive errors', () {
-      final String code = '''
+      const code = '''
 import 'dart:foo';
 void main() { print ('foo'); }
 ''';

--- a/test/dartpad_server_test.dart
+++ b/test/dartpad_server_test.dart
@@ -94,7 +94,7 @@ void defineTests() {
       expect(response.status, 200);
       var data = json.decode(utf8.decode(await response.body.first));
       expect(data['uuid'], isNotNull);
-      jsonData = {'uuid': data['uuid']};
+      jsonData = {'uuid': data['uuid'] as String};
       var pull = await _sendPostRequest(
           '_dartpadsupportservices/v1/pullExportData', jsonData);
       expect(pull.status, 200);

--- a/test/gae_deployed_test.dart
+++ b/test/gae_deployed_test.dart
@@ -24,7 +24,7 @@ void defineTests({bool skip = true}) {
 
 void analyzeTest() {
   final String url = '$serverUrl/api/analyze';
-  Map headers = {'Content-Type': 'text/plain; charset=UTF-8'};
+  Map<String,String> headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 
   expect(
       http
@@ -39,7 +39,7 @@ void analyzeTest() {
 
 void compileTest() {
   final String url = '$serverUrl/api/compile';
-  Map headers = {'Content-Type': 'text/plain; charset=UTF-8'};
+  Map<String,String> headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 
   expect(
       http
@@ -54,7 +54,7 @@ void compileTest() {
 
 void compileDDCTest() {
   final String url = '$serverUrl/api/compileDDC';
-  Map headers = {'Content-Type': 'text/plain; charset=UTF-8'};
+  Map<String,String> headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 
   expect(
       http

--- a/test/gae_deployed_test.dart
+++ b/test/gae_deployed_test.dart
@@ -22,7 +22,7 @@ void defineTests({bool skip = true}) {
 
 void analyzeTest() {
   final String url = '$serverUrl/api/analyze';
-  Map<String,String> headers = {'Content-Type': 'text/plain; charset=UTF-8'};
+  final headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 
   expect(
       http
@@ -37,7 +37,7 @@ void analyzeTest() {
 
 void compileTest() {
   final String url = '$serverUrl/api/compile';
-  Map<String,String> headers = {'Content-Type': 'text/plain; charset=UTF-8'};
+  final headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 
   expect(
       http
@@ -52,7 +52,7 @@ void compileTest() {
 
 void compileDDCTest() {
   final String url = '$serverUrl/api/compileDDC';
-  Map<String,String> headers = {'Content-Type': 'text/plain; charset=UTF-8'};
+  final headers = {'Content-Type': 'text/plain; charset=UTF-8'};
 
   expect(
       http

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -23,7 +23,7 @@ void defineTests() {
     });
 
     test('one', () {
-      final String source = '''
+      const source = '''
 library woot;
 import 'dart:math';
 import 'package:foo/foo.dart';
@@ -34,7 +34,7 @@ void main() { }
     });
 
     test('two', () {
-      final String source = '''
+      const source = '''
 library woot;
 import 'dart:math';
  import 'package:foo/foo.dart';
@@ -48,7 +48,7 @@ void main() { }
     });
 
     test('three', () {
-      final String source = '''
+      const source = '''
 library woot;
 import 'dart:math';
 import 'package:foo/foo.dart';
@@ -70,14 +70,14 @@ void main() { }
 
   group('filterSafePackagesFromImports', () {
     test('empty', () {
-      final String source = '''import 'package:';
+      const source = '''import 'package:';
 void main() { }
 ''';
       expect(filterSafePackagesFromImports(getAllImportsFor(source)), isEmpty);
     });
 
     test('simple', () {
-      final String source = '''
+      const source = '''
 import 'package:foo/foo.dart';
 import 'package:bar/bar.dart';
 void main() { }
@@ -87,32 +87,32 @@ void main() { }
     });
 
     test('defensive', () {
-      final String source = '''
+      const source = '''
 library woot;
 import 'dart:math';
 import 'package:../foo/foo.dart';
 void main() { }
 ''';
-      Set<String> imports = getAllImportsFor(source);
+      final imports = getAllImportsFor(source);
       expect(
           imports, unorderedMatches(['dart:math', 'package:../foo/foo.dart']));
       expect(filterSafePackagesFromImports(imports), isEmpty);
     });
 
     test('negative dart import', () {
-      final String source = '''
+      const source = '''
 import 'dart:../bar.dart';
 ''';
-      Set<String> imports = getAllImportsFor(source);
+      final imports = getAllImportsFor(source);
       expect(imports, unorderedMatches(['dart:../bar.dart']));
       expect(filterSafePackagesFromImports(imports), isEmpty);
     });
 
     test('negative path import', () {
-      final String source = '''
+      const source = '''
 import '../foo.dart';
 ''';
-      Set<String> imports = getAllImportsFor(source);
+      final imports = getAllImportsFor(source);
       expect(imports, unorderedMatches(['../foo.dart']));
       expect(filterSafePackagesFromImports(imports), isEmpty);
     });

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -95,7 +95,7 @@ import 'dart:math';
 import 'package:../foo/foo.dart';
 void main() { }
 ''';
-      Set imports = getAllImportsFor(source);
+      Set<String> imports = getAllImportsFor(source);
       expect(
           imports, unorderedMatches(['dart:math', 'package:../foo/foo.dart']));
       expect(filterSafePackagesFromImports(imports), isEmpty);
@@ -105,7 +105,7 @@ void main() { }
       final String source = '''
 import 'dart:../bar.dart';
 ''';
-      Set imports = getAllImportsFor(source);
+      Set<String> imports = getAllImportsFor(source);
       expect(imports, unorderedMatches(['dart:../bar.dart']));
       expect(filterSafePackagesFromImports(imports), isEmpty);
     });
@@ -114,7 +114,7 @@ import 'dart:../bar.dart';
       final String source = '''
 import '../foo.dart';
 ''';
-      Set imports = getAllImportsFor(source);
+      Set<String> imports = getAllImportsFor(source);
       expect(imports, unorderedMatches(['../foo.dart']));
       expect(filterSafePackagesFromImports(imports), isEmpty);
     });

--- a/test/summarize_test.dart
+++ b/test/summarize_test.dart
@@ -12,12 +12,12 @@ void main() => defineTests();
 void defineTests() {
   group('Summarizer helpers', () {
     test('Unique case detection in list', () {
-      Summarizer summer = Summarizer(dart: 'pirate');
+      final summer = Summarizer(dart: 'pirate');
       expect(summer.additionSearch(), contains('pirates'));
     });
 
     test('Unique case detection no false triggers in list', () {
-      Summarizer summer = Summarizer(dart: 'll not amma, pir not ates');
+      final summer = Summarizer(dart: 'll not amma, pir not ates');
       expect(summer.additionSearch(), isNot(contains('pirates')));
       expect(summer.additionSearch(), isNot(contains('dogs')));
       expect(summer.additionSearch(), isNot(contains('birds')));
@@ -27,12 +27,12 @@ void defineTests() {
 
   group('Summarizer', () {
     test('Non-null input does not fail', () {
-      Summarizer summer = Summarizer(dart: 'Test.');
+      final summer = Summarizer(dart: 'Test.');
       expect(summer.returnAsSimpleSummary(), isNotNull);
     });
 
     test('returnAsMarkDown', () {
-      Summarizer summer = Summarizer(dart: 'Test.');
+      final summer = Summarizer(dart: 'Test.');
       expect(summer.returnAsMarkDown(), isNotNull);
     });
 
@@ -41,19 +41,19 @@ void defineTests() {
     });
 
     test('Same input causes same output', () {
-      Summarizer summer1 = Summarizer(dart: 'Test case one.');
-      Summarizer summer2 = Summarizer(dart: 'Test case one.');
+      final summer1 = Summarizer(dart: 'Test case one.');
+      final summer2 = Summarizer(dart: 'Test case one.');
       expect(summer1.returnAsSimpleSummary(),
           equals(summer2.returnAsSimpleSummary()));
     });
 
     test('Unique case detection', () {
-      Summarizer summer = Summarizer(dart: 'pirate');
+      final summer = Summarizer(dart: 'pirate');
       expect(summer.returnAsSimpleSummary(), contains('pirates'));
     });
 
     test('Unique case detection', () {
-      Summarizer summer = Summarizer(dart: 'pirate, dog, bird, llama');
+      final summer = Summarizer(dart: 'pirate, dog, bird, llama');
       expect(summer.returnAsSimpleSummary(), contains('pirates'));
       expect(summer.returnAsSimpleSummary(), contains('dogs'));
       expect(summer.returnAsSimpleSummary(), contains('birds'));
@@ -61,7 +61,7 @@ void defineTests() {
     });
 
     test('Unique case detection no false triggers', () {
-      Summarizer summer = Summarizer(dart: 'll not amma, pir not ates');
+      final summer = Summarizer(dart: 'll not amma, pir not ates');
       expect(summer.returnAsSimpleSummary(), isNot(contains('pirates')));
       expect(summer.returnAsSimpleSummary(), isNot(contains('dogs')));
       expect(summer.returnAsSimpleSummary(), isNot(contains('birds')));
@@ -69,23 +69,23 @@ void defineTests() {
     });
 
     test('Modification causes change', () {
-      Summarizer summer1 = Summarizer(dart: 'this does not return anything');
-      Summarizer summer2 = Summarizer(dart: 'this doesnt return anything');
+      final summer1 = Summarizer(dart: 'this does not return anything');
+      final summer2 = Summarizer(dart: 'this doesnt return anything');
       expect(summer1.returnAsSimpleSummary(),
           isNot(summer2.returnAsSimpleSummary()));
     });
 
     test('Same input same output', () {
-      Summarizer summer1 = Summarizer(dart: 'this does not return anything');
-      Summarizer summer2 = Summarizer(dart: 'this does not return anything');
+      final summer1 = Summarizer(dart: 'this does not return anything');
+      final summer2 = Summarizer(dart: 'this does not return anything');
       expect(summer1.returnAsSimpleSummary(),
           equals(summer2.returnAsSimpleSummary()));
     });
 
     test('Html and css detection', () {
-      Summarizer summer1 =
+      final summer1 =
           Summarizer(dart: 'this does not return anything', html: '<div/>');
-      Summarizer summer2 = Summarizer(dart: 'this does not return anything');
+      final summer2 = Summarizer(dart: 'this does not return anything');
       expect(summer1.returnAsSimpleSummary(),
           isNot(equals(summer2.returnAsSimpleSummary())));
     });

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -69,7 +69,7 @@ Usage: slow_test path_to_test_collection
   String sdk = sdkPath;
 
   // Load the list of files.
-  var fileEntities = [];
+  var fileEntities = <io.FileSystemEntity>[];
   if (io.FileSystemEntity.isDirectorySync(testCollectionRoot)) {
     io.Directory dir = io.Directory(testCollectionRoot);
     fileEntities = dir.listSync(recursive: true);


### PR DESCRIPTION
At the suggestion of @natebosch, this PR restricts implicit casts to make sure we don't get back into the case where we error out with List<String> not being a sub-type of List<Object>.

Thoughts? 

/cc @RedBrogdon 