### PR TITLE
pass --library-root as the temp dir to fix library names

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -144,6 +144,7 @@ class Compiler {
       arguments.add('--single-out-file');
       arguments.addAll(<String>['--module-name', 'dartpad_main']);
       arguments.add(compileTarget);
+      arguments.addAll(<String>['--library-root', temp.path]);
 
       File mainJs = File(path.join(temp.path, '$kMainDart.js'));
 


### PR DESCRIPTION
Fixes library names for ddc modules to be relative to the temp dir (so now it is just `main` when before it was a much longer thing with a bunch of underscores).