### PR TITLE
Update flutter_web.dart not not add an explicit test dep

### DIFF
--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -167,13 +167,9 @@ $_samplePackageName:lib/
 name: $_samplePackageName
 ''';
 
-    // TODO(devoncarew): We only add the 'test' dep below as
-    // package:flutter_web_test incorrectly lists its test dependency as a dev
-    // dependency; it should list it as a regular dependency.
     if (includeFlutterWeb) {
       content += '''
 dependencies:
-  test: any
   flutter_web:
     git:
       url: https://github.com/flutter/flutter_web


### PR DESCRIPTION
We no longer need this, as of https://github.com/flutter/flutter_web/commit/df052476ba713075e6e7238d4842deb80d7eb611.