### PR TITLE
upload compressed compilation artifacts

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -175,11 +175,11 @@ void _buildStorageArtifacts(Directory dir) {
 
   // emit some good google storage upload instructions
   final String version = File('dart-sdk.version').readAsStringSync().trim();
-  log('\nFrom the artifacts/ dir, run:');
-  log('  gsutil -h "Cache-Control:public, max-age=86400" cp *.js '
-      'gs://compilation_artifacts/$version/');
-  log('  gsutil -h "Cache-Control:public, max-age=86400" cp *.sum '
-      'gs://compilation_artifacts/$version/');
+  log('\nFrom the dart-services project root dir, run:');
+  log('  gsutil -h "Cache-Control:public, max-age=86400" cp -z js '
+      'artifacts/*.js gs://compilation_artifacts/$version/');
+  log('  gsutil -h "Cache-Control:public, max-age=86400" cp -z sum '
+      'artifacts/*.sum gs://compilation_artifacts/$version/');
 }
 
 @Task()


### PR DESCRIPTION
- use a gsutil option to upload compressed compilation artifacts

These will be downloaded by http clients via a gzip transfer encoding. The ~5MB and ~11MB js artifacts are now 500kb and 1.4MB.

We'll still want to work on addressing https://github.com/dart-lang/dart-pad/issues/1018, which will speed up re-runs of an app quite a bit.