### PR TITLE
filter out completion results that don't start with the replacement text

### DIFF
--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -332,7 +332,10 @@ class AnalysisServerWrapper {
       );
       CompletionResults results = await getCompletionResults(id.id);
       await _unloadSources();
-      return results;
+      var source = sources[_getPathFromName(sourceName)];
+      var prefix = source.substring(results.replacementOffset,
+          results.replacementOffset + results.replacementLength);
+      return _completionResultsOnlyWithPrefix(results, prefix);
     }, timeoutDuration: _ANALYSIS_SERVER_TIMEOUT));
   }
 
@@ -439,6 +442,15 @@ class AnalysisServerWrapper {
         }
       }
     });
+  }
+
+  CompletionResults _completionResultsOnlyWithPrefix(
+      CompletionResults results, String prevPattern) {
+    var filteredResults = results.results
+        .where((s) => s.completion.startsWith(prevPattern))
+        .toList();
+    return CompletionResults(results.id, results.replacementOffset,
+        results.replacementLength, filteredResults, results.isLast);
   }
 
   Future<CompletionResults> getCompletionResults(String id) {

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -128,7 +128,8 @@ class AnalysisServerWrapper {
     var source = sources[location.sourceName];
     var prefix = source.substring(results.replacementOffset, location.offset);
     suggestions = suggestions
-        .where((s) => s.completion.startsWith(prefix))
+        .where(
+            (s) => s.completion.toLowerCase().startsWith(prefix.toLowerCase()))
         // This hack filters out of scope completions. It needs removing when we
         // have categories of completions.
         // TODO(devoncarew): Remove this filter code.

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -23,6 +23,16 @@ void main() {
 }
 ''';
 
+const completionLargeNamespaces = r'''
+class A {}
+class AB {}
+class ABC {}
+void main() {
+  var c = A
+}
+class ZZ {}
+''';
+
 const quickFixesCode = r'''
 void main() {
   int i = 0
@@ -92,7 +102,6 @@ void defineTests() {
     test('import_test', () {
       String testCode = "import '/'; main() { int a = 0; a. }";
 
-      //Just after i.
       return analysisServer
           .complete(testCode, 9)
           .then((CompleteResponse results) {
@@ -105,7 +114,6 @@ void defineTests() {
     test('import_and_other_test', () {
       String testCode = "import '/'; main() { int a = 0; a. }";
 
-      //Just after i.
       return analysisServer
           .complete(testCode, 34)
           .then((CompleteResponse results) {
@@ -114,7 +122,6 @@ void defineTests() {
     });
 
     test('simple_quickFix', () {
-      //Just after i.
       return analysisServer
           .getFixes(quickFixesCode, 25)
           .then((FixesResponse results) {
@@ -175,6 +182,20 @@ void defineTests() {
 
       AnalysisResults results = await analysisServer.analyze(sampleDart2OK);
       expect(results.issues, hasLength(0));
+    });
+
+    test('filter completions', () async {
+      // just after A
+      var idx = 61;
+      expect(completionLargeNamespaces.substring(idx - 1, idx), 'A');
+      return analysisServer
+          .complete(completionLargeNamespaces, 61)
+          .then((CompleteResponse results) {
+        expect(completionsContains(results, 'A'), true);
+        expect(completionsContains(results, 'AB'), true);
+        expect(completionsContains(results, 'ABC'), true);
+        expect(completionsContains(results, 'ZZ'), false);
+      });
     });
   });
 }

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -31,6 +31,7 @@ void main() {
   var c = A
 }
 class ZZ {}
+class a {}
 ''';
 
 const quickFixesCode = r'''
@@ -193,6 +194,7 @@ void defineTests() {
       expect(completionsContains(results, 'A'), true);
       expect(completionsContains(results, 'AB'), true);
       expect(completionsContains(results, 'ABC'), true);
+      expect(completionsContains(results, 'a'), true);
       expect(completionsContains(results, 'ZZ'), false);
     });
   });

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -188,14 +188,12 @@ void defineTests() {
       // just after A
       var idx = 61;
       expect(completionLargeNamespaces.substring(idx - 1, idx), 'A');
-      return analysisServer
-          .complete(completionLargeNamespaces, 61)
-          .then((CompleteResponse results) {
-        expect(completionsContains(results, 'A'), true);
-        expect(completionsContains(results, 'AB'), true);
-        expect(completionsContains(results, 'ABC'), true);
-        expect(completionsContains(results, 'ZZ'), false);
-      });
+      var results =
+          await analysisServer.complete(completionLargeNamespaces, 61);
+      expect(completionsContains(results, 'A'), true);
+      expect(completionsContains(results, 'AB'), true);
+      expect(completionsContains(results, 'ABC'), true);
+      expect(completionsContains(results, 'ZZ'), false);
     });
   });
 }


### PR DESCRIPTION
I'm not sure if this is going to work for all scenarios... I've done some basic testing with the new embeddable editor

![Screen Shot 2019-04-30 at 3 24 47 PM](https://user-images.githubusercontent.com/1145719/56997544-fc907680-6b5c-11e9-966d-2584572166ca.png)


closes dart-lang/dart-pad/#1014