### PR TITLE
remove deprecated APIs

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -62,77 +62,6 @@ class DartservicesApi {
     return _response.then((data) => new AnalysisResults.fromJson(data));
   }
 
-  /// Request parameters:
-  ///
-  /// [source] - Query parameter: 'source'.
-  ///
-  /// Completes with a [AnalysisResults].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<AnalysisResults> analyzeGet({core.String source}) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (source != null) {
-      _queryParams["source"] = [source];
-    }
-
-    _url = 'analyze';
-
-    var _response = _requester.request(_url, "GET",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new AnalysisResults.fromJson(data));
-  }
-
-  /// Analyze the given Dart source code and return any resulting analysis
-  /// errors or warnings.
-  ///
-  /// [request] - The metadata request object.
-  ///
-  /// Request parameters:
-  ///
-  /// Completes with a [AnalysisResults].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<AnalysisResults> analyzeMulti(SourcesRequest request) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (request != null) {
-      _body = convert.json.encode((request).toJson());
-    }
-
-    _url = 'analyzeMulti';
-
-    var _response = _requester.request(_url, "POST",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new AnalysisResults.fromJson(data));
-  }
-
   /// Compile the given Dart source code and return the resulting JavaScript;
   /// this uses the dart2js compiler.
   ///
@@ -207,40 +136,6 @@ class DartservicesApi {
     return _response.then((data) => new CompileDDCResponse.fromJson(data));
   }
 
-  /// Request parameters:
-  ///
-  /// [source] - Query parameter: 'source'.
-  ///
-  /// Completes with a [CompileResponse].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<CompileResponse> compileGet({core.String source}) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (source != null) {
-      _queryParams["source"] = [source];
-    }
-
-    _url = 'compile';
-
-    var _response = _requester.request(_url, "GET",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new CompileResponse.fromJson(data));
-  }
-
   /// Get the valid code completion results for the given offset.
   ///
   /// [request] - The metadata request object.
@@ -267,82 +162,6 @@ class DartservicesApi {
     }
 
     _url = 'complete';
-
-    var _response = _requester.request(_url, "POST",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new CompleteResponse.fromJson(data));
-  }
-
-  /// Request parameters:
-  ///
-  /// [source] - Query parameter: 'source'.
-  ///
-  /// [offset] - Query parameter: 'offset'.
-  ///
-  /// Completes with a [CompleteResponse].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<CompleteResponse> completeGet(
-      {core.String source, core.int offset}) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (source != null) {
-      _queryParams["source"] = [source];
-    }
-    if (offset != null) {
-      _queryParams["offset"] = ["${offset}"];
-    }
-
-    _url = 'complete';
-
-    var _response = _requester.request(_url, "GET",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new CompleteResponse.fromJson(data));
-  }
-
-  /// Get the valid code completion results for the given offset.
-  ///
-  /// [request] - The metadata request object.
-  ///
-  /// Request parameters:
-  ///
-  /// Completes with a [CompleteResponse].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<CompleteResponse> completeMulti(SourcesRequest request) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (request != null) {
-      _body = convert.json.encode((request).toJson());
-    }
-
-    _url = 'completeMulti';
 
     var _response = _requester.request(_url, "POST",
         body: _body,
@@ -390,46 +209,6 @@ class DartservicesApi {
     return _response.then((data) => new DocumentResponse.fromJson(data));
   }
 
-  /// Request parameters:
-  ///
-  /// [source] - Query parameter: 'source'.
-  ///
-  /// [offset] - Query parameter: 'offset'.
-  ///
-  /// Completes with a [DocumentResponse].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<DocumentResponse> documentGet(
-      {core.String source, core.int offset}) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (source != null) {
-      _queryParams["source"] = [source];
-    }
-    if (offset != null) {
-      _queryParams["offset"] = ["${offset}"];
-    }
-
-    _url = 'document';
-
-    var _response = _requester.request(_url, "GET",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new DocumentResponse.fromJson(data));
-  }
-
   /// Get any quick fixes for the given source code location.
   ///
   /// [request] - The metadata request object.
@@ -456,81 +235,6 @@ class DartservicesApi {
     }
 
     _url = 'fixes';
-
-    var _response = _requester.request(_url, "POST",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new FixesResponse.fromJson(data));
-  }
-
-  /// Request parameters:
-  ///
-  /// [source] - Query parameter: 'source'.
-  ///
-  /// [offset] - Query parameter: 'offset'.
-  ///
-  /// Completes with a [FixesResponse].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<FixesResponse> fixesGet({core.String source, core.int offset}) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (source != null) {
-      _queryParams["source"] = [source];
-    }
-    if (offset != null) {
-      _queryParams["offset"] = ["${offset}"];
-    }
-
-    _url = 'fixes';
-
-    var _response = _requester.request(_url, "GET",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new FixesResponse.fromJson(data));
-  }
-
-  /// Get any quick fixes for the given source code location.
-  ///
-  /// [request] - The metadata request object.
-  ///
-  /// Request parameters:
-  ///
-  /// Completes with a [FixesResponse].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<FixesResponse> fixesMulti(SourcesRequest request) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (request != null) {
-      _body = convert.json.encode((request).toJson());
-    }
-
-    _url = 'fixesMulti';
 
     var _response = _requester.request(_url, "POST",
         body: _body,
@@ -577,83 +281,6 @@ class DartservicesApi {
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
     return _response.then((data) => new FormatResponse.fromJson(data));
-  }
-
-  /// Request parameters:
-  ///
-  /// [source] - Query parameter: 'source'.
-  ///
-  /// [offset] - Query parameter: 'offset'.
-  ///
-  /// Completes with a [FormatResponse].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<FormatResponse> formatGet(
-      {core.String source, core.int offset}) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (source != null) {
-      _queryParams["source"] = [source];
-    }
-    if (offset != null) {
-      _queryParams["offset"] = ["${offset}"];
-    }
-
-    _url = 'format';
-
-    var _response = _requester.request(_url, "GET",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new FormatResponse.fromJson(data));
-  }
-
-  /// Summarize the given Dart source code and return any resulting analysis
-  /// errors or warnings.
-  ///
-  /// [request] - The metadata request object.
-  ///
-  /// Request parameters:
-  ///
-  /// Completes with a [SummaryText].
-  ///
-  /// Completes with a [commons.ApiRequestError] if the API endpoint returned an
-  /// error.
-  ///
-  /// If the used [http.Client] completes with an error when making a REST call,
-  /// this method will complete with the same error.
-  async.Future<SummaryText> summarize(SourcesRequest request) {
-    var _url = null;
-    var _queryParams = new core.Map<core.String, core.List<core.String>>();
-    var _uploadMedia = null;
-    var _uploadOptions = null;
-    var _downloadOptions = commons.DownloadOptions.Metadata;
-    var _body = null;
-
-    if (request != null) {
-      _body = convert.json.encode((request).toJson());
-    }
-
-    _url = 'summarize';
-
-    var _response = _requester.request(_url, "POST",
-        body: _body,
-        queryParams: _queryParams,
-        uploadOptions: _uploadOptions,
-        uploadMedia: _uploadMedia,
-        downloadOptions: _downloadOptions);
-    return _response.then((data) => new SummaryText.fromJson(data));
   }
 
   /// Return the current SDK version for DartServices.
@@ -1017,34 +644,6 @@ class FormatResponse {
   }
 }
 
-class Location {
-  core.int offset;
-  core.String sourceName;
-
-  Location();
-
-  Location.fromJson(core.Map _json) {
-    if (_json.containsKey("offset")) {
-      offset = _json["offset"];
-    }
-    if (_json.containsKey("sourceName")) {
-      sourceName = _json["sourceName"];
-    }
-  }
-
-  core.Map<core.String, core.Object> toJson() {
-    final core.Map<core.String, core.Object> _json =
-        new core.Map<core.String, core.Object>();
-    if (offset != null) {
-      _json["offset"] = offset;
-    }
-    if (sourceName != null) {
-      _json["sourceName"] = sourceName;
-    }
-    return _json;
-  }
-}
-
 class ProblemAndFixes {
   core.List<CandidateFix> fixes;
   core.int length;
@@ -1159,67 +758,6 @@ class SourceRequest {
     }
     if (strongMode != null) {
       _json["strongMode"] = strongMode;
-    }
-    return _json;
-  }
-}
-
-class SourcesRequest {
-  /// An optional location in the source code.
-  Location location;
-
-  /// Map of names to Sources.
-  core.Map<core.String, core.String> sources;
-
-  /// Ignored: always treated as true.
-  core.bool strongMode;
-
-  SourcesRequest();
-
-  SourcesRequest.fromJson(core.Map _json) {
-    if (_json.containsKey("location")) {
-      location = new Location.fromJson(_json["location"]);
-    }
-    if (_json.containsKey("sources")) {
-      sources = (_json["sources"] as core.Map).cast<core.String, core.String>();
-    }
-    if (_json.containsKey("strongMode")) {
-      strongMode = _json["strongMode"];
-    }
-  }
-
-  core.Map<core.String, core.Object> toJson() {
-    final core.Map<core.String, core.Object> _json =
-        new core.Map<core.String, core.Object>();
-    if (location != null) {
-      _json["location"] = (location).toJson();
-    }
-    if (sources != null) {
-      _json["sources"] = sources;
-    }
-    if (strongMode != null) {
-      _json["strongMode"] = strongMode;
-    }
-    return _json;
-  }
-}
-
-class SummaryText {
-  core.String text;
-
-  SummaryText();
-
-  SummaryText.fromJson(core.Map _json) {
-    if (_json.containsKey("text")) {
-      text = _json["text"];
-    }
-  }
-
-  core.Map<core.String, core.Object> toJson() {
-    final core.Map<core.String, core.Object> _json =
-        new core.Map<core.String, core.Object>();
-    if (text != null) {
-      _json["text"] = text;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "dae0b714d4f8d5bd3d0926341491efd8ef566973",
+ "etag": "01e0e3c74f6692a3077d117bb98b1cbeb3d832d0",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -79,50 +79,6 @@
     "charLength": {
      "type": "integer",
      "format": "int32"
-    }
-   }
-  },
-  "SourcesRequest": {
-   "id": "SourcesRequest",
-   "type": "object",
-   "properties": {
-    "sources": {
-     "type": "object",
-     "description": "Map of names to Sources.",
-     "required": true,
-     "additionalProperties": {
-      "type": "string"
-     }
-    },
-    "location": {
-     "$ref": "Location",
-     "description": "An optional location in the source code."
-    },
-    "strongMode": {
-     "type": "boolean",
-     "description": "Ignored: always treated as true."
-    }
-   }
-  },
-  "Location": {
-   "id": "Location",
-   "type": "object",
-   "properties": {
-    "sourceName": {
-     "type": "string"
-    },
-    "offset": {
-     "type": "integer",
-     "format": "int32"
-    }
-   }
-  },
-  "SummaryText": {
-   "id": "SummaryText",
-   "type": "object",
-   "properties": {
-    "text": {
-     "type": "string"
     }
    }
   },
@@ -326,51 +282,6 @@
     "$ref": "AnalysisResults"
    }
   },
-  "analyzeMulti": {
-   "id": "CommonServer.analyzeMulti",
-   "path": "analyzeMulti",
-   "httpMethod": "POST",
-   "description": "Analyze the given Dart source code and return any resulting analysis errors or warnings.",
-   "parameters": {},
-   "parameterOrder": [],
-   "request": {
-    "$ref": "SourcesRequest"
-   },
-   "response": {
-    "$ref": "AnalysisResults"
-   }
-  },
-  "summarize": {
-   "id": "CommonServer.summarize",
-   "path": "summarize",
-   "httpMethod": "POST",
-   "description": "Summarize the given Dart source code and return any resulting analysis errors or warnings.",
-   "parameters": {},
-   "parameterOrder": [],
-   "request": {
-    "$ref": "SourcesRequest"
-   },
-   "response": {
-    "$ref": "SummaryText"
-   }
-  },
-  "analyzeGet": {
-   "id": "CommonServer.analyzeGet",
-   "path": "analyze",
-   "httpMethod": "GET",
-   "parameters": {
-    "source": {
-     "type": "string",
-     "description": "Query parameter: 'source'.",
-     "required": false,
-     "location": "query"
-    }
-   },
-   "parameterOrder": [],
-   "response": {
-    "$ref": "AnalysisResults"
-   }
-  },
   "compile": {
    "id": "CommonServer.compile",
    "path": "compile",
@@ -381,23 +292,6 @@
    "request": {
     "$ref": "CompileRequest"
    },
-   "response": {
-    "$ref": "CompileResponse"
-   }
-  },
-  "compileGet": {
-   "id": "CommonServer.compileGet",
-   "path": "compile",
-   "httpMethod": "GET",
-   "parameters": {
-    "source": {
-     "type": "string",
-     "description": "Query parameter: 'source'.",
-     "required": false,
-     "location": "query"
-    }
-   },
-   "parameterOrder": [],
    "response": {
     "$ref": "CompileResponse"
    }
@@ -430,43 +324,6 @@
     "$ref": "CompleteResponse"
    }
   },
-  "completeMulti": {
-   "id": "CommonServer.completeMulti",
-   "path": "completeMulti",
-   "httpMethod": "POST",
-   "description": "Get the valid code completion results for the given offset.",
-   "parameters": {},
-   "parameterOrder": [],
-   "request": {
-    "$ref": "SourcesRequest"
-   },
-   "response": {
-    "$ref": "CompleteResponse"
-   }
-  },
-  "completeGet": {
-   "id": "CommonServer.completeGet",
-   "path": "complete",
-   "httpMethod": "GET",
-   "parameters": {
-    "source": {
-     "type": "string",
-     "description": "Query parameter: 'source'.",
-     "required": false,
-     "location": "query"
-    },
-    "offset": {
-     "type": "integer",
-     "description": "Query parameter: 'offset'.",
-     "required": false,
-     "location": "query"
-    }
-   },
-   "parameterOrder": [],
-   "response": {
-    "$ref": "CompleteResponse"
-   }
-  },
   "fixes": {
    "id": "CommonServer.fixes",
    "path": "fixes",
@@ -477,43 +334,6 @@
    "request": {
     "$ref": "SourceRequest"
    },
-   "response": {
-    "$ref": "FixesResponse"
-   }
-  },
-  "fixesMulti": {
-   "id": "CommonServer.fixesMulti",
-   "path": "fixesMulti",
-   "httpMethod": "POST",
-   "description": "Get any quick fixes for the given source code location.",
-   "parameters": {},
-   "parameterOrder": [],
-   "request": {
-    "$ref": "SourcesRequest"
-   },
-   "response": {
-    "$ref": "FixesResponse"
-   }
-  },
-  "fixesGet": {
-   "id": "CommonServer.fixesGet",
-   "path": "fixes",
-   "httpMethod": "GET",
-   "parameters": {
-    "source": {
-     "type": "string",
-     "description": "Query parameter: 'source'.",
-     "required": false,
-     "location": "query"
-    },
-    "offset": {
-     "type": "integer",
-     "description": "Query parameter: 'offset'.",
-     "required": false,
-     "location": "query"
-    }
-   },
-   "parameterOrder": [],
    "response": {
     "$ref": "FixesResponse"
    }
@@ -532,29 +352,6 @@
     "$ref": "FormatResponse"
    }
   },
-  "formatGet": {
-   "id": "CommonServer.formatGet",
-   "path": "format",
-   "httpMethod": "GET",
-   "parameters": {
-    "source": {
-     "type": "string",
-     "description": "Query parameter: 'source'.",
-     "required": false,
-     "location": "query"
-    },
-    "offset": {
-     "type": "integer",
-     "description": "Query parameter: 'offset'.",
-     "required": false,
-     "location": "query"
-    }
-   },
-   "parameterOrder": [],
-   "response": {
-    "$ref": "FormatResponse"
-   }
-  },
   "document": {
    "id": "CommonServer.document",
    "path": "document",
@@ -565,29 +362,6 @@
    "request": {
     "$ref": "SourceRequest"
    },
-   "response": {
-    "$ref": "DocumentResponse"
-   }
-  },
-  "documentGet": {
-   "id": "CommonServer.documentGet",
-   "path": "document",
-   "httpMethod": "GET",
-   "parameters": {
-    "source": {
-     "type": "string",
-     "description": "Query parameter: 'source'.",
-     "required": false,
-     "location": "query"
-    },
-    "offset": {
-     "type": "integer",
-     "description": "Query parameter: 'offset'.",
-     "required": false,
-     "location": "query"
-    }
-   },
-   "parameterOrder": [],
    "response": {
     "$ref": "DocumentResponse"
    }

--- a/example/apitest.dart
+++ b/example/apitest.dart
@@ -29,7 +29,6 @@ void main() {
 void setupDartpadServices() {
   setupExport();
   setupRetrieve();
-  setupSummary();
   setupIdRetrieval();
   setupGistStore();
   setupGistRetrieval();
@@ -40,24 +39,6 @@ void _setupClients() {
   servicesApi = services.DartservicesApi(client, rootUrl: _uriBase);
   _dartpadSupportApi =
       support.P_dartpadsupportservicesApi(client, rootUrl: _uriBase);
-}
-
-void setupSummary() {
-  CodeMirror editor = createEditor(querySelector('#summarySection .editor'));
-  Element output = querySelector('#summarySection .output');
-  ButtonElement button = querySelector('#summarySection button') as ButtonElement;
-  button.onClick.listen((e) {
-    _setupClients();
-    services.SourcesRequest input = services.SourcesRequest();
-    input.sources = <String, String>{};
-    input.sources['dart'] = editor.getDoc().getValue();
-    input.sources['css'] = '';
-    input.sources['html'] = '';
-    Stopwatch sw = Stopwatch()..start();
-    servicesApi.summarize(input).then((results) {
-      output.text = '${_formatTiming(sw)}${results.toJson()}';
-    });
-  });
 }
 
 void setupIdRetrieval() {

--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -74,7 +74,7 @@ class GaeServer {
         flutterWebManager,
         GaeServerContainer(),
         redisServerUri == null
-            ? InmemoryCache()
+            ? InMemoryCache()
             : RedisCache(
                 redisServerUri, io.Platform.environment['GAE_VERSION']));
     // Enabled pretty printing of returned json for debuggability.

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -112,15 +112,10 @@ class AnalysisServerWrapper {
     });
   }
 
-  Future<api.CompleteResponse> complete(String src, int offset) {
-    return completeMulti(
-      <String, String>{kMainDart: src},
-      api.Location.from(kMainDart, offset),
-    );
-  }
+  Future<api.CompleteResponse> complete(String src, int offset) async {
+    Map<String, String> sources = <String, String>{kMainDart: src};
+    api.Location location = api.Location.from(kMainDart, offset);
 
-  Future<api.CompleteResponse> completeMulti(
-      Map<String, String> sources, api.Location location) async {
     CompletionResults results =
         await _completeImpl(sources, location.sourceName, location.offset);
     List<CompletionSuggestion> suggestions = results.results;
@@ -227,10 +222,8 @@ class AnalysisServerWrapper {
   }
 
   Future<api.AnalysisResults> analyze(String source) {
-    return analyzeMulti(<String, String>{kMainDart: source});
-  }
+    Map<String, String> sources = <String, String>{kMainDart: source};
 
-  Future<api.AnalysisResults> analyzeMulti(Map<String, String> sources) {
     _logger
         .fine('analyzeMulti: Scheduler queue: ${serverScheduler.queueCount}');
 
@@ -312,7 +305,7 @@ class AnalysisServerWrapper {
   /// Cleanly shutdown the Analysis Server.
   Future<dynamic> shutdown() {
     // TODO(jcollins-g): calling dispose() sometimes prevents
-    // --pause-isolates-on-exit from working.  Fix.
+    // --pause-isolates-on-exit from working; fix.
     return analysisServer.server
         .shutdown()
         .timeout(Duration(seconds: 1))

--- a/test/common_server_test.dart
+++ b/test/common_server_test.dart
@@ -519,37 +519,6 @@ void defineTests() {
       expect(data['sdkVersion'], isNotNull);
       expect(data['runtimeVersion'], isNotNull);
     });
-
-    test('summarize', () async {
-      Map<String, dynamic> jsonData = {
-        'sources': <String, String>{'dart': sampleCode, 'html': '', 'css': ''}
-      };
-      var response =
-          await _sendPostRequest('dartservices/v1/summarize', jsonData);
-      expect(response.status, 200);
-      var data = json.decode(utf8.decode(await response.body.first));
-      expect(data['text'], isNotNull);
-    });
-
-    test('summarizeDifferent', () async {
-      var jsonOne = {
-        'sources': {'dart': sampleCode, 'html': '', 'css': ''}
-      };
-      var response =
-          await _sendPostRequest('dartservices/v1/summarize', jsonOne);
-      expect(response.status, 200);
-      var data = json.decode(utf8.decode(await response.body.first));
-      expect(data['text'], isNotNull);
-      var jsonTwo = {
-        'sources': {'dart': quickFixesCode, 'html': '', 'css': ''}
-      };
-      var responseTwo =
-          await _sendPostRequest('dartservices/v1/summarize', jsonTwo);
-      expect(responseTwo.status, 200);
-      var dataTwo = json.decode(utf8.decode(await responseTwo.body.first));
-      expect(dataTwo['text'], isNotNull);
-      expect(dataTwo['text'] == data['text'], false);
-    });
   });
 }
 

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -299,7 +299,10 @@ Future<num> testCompletions(
     if (i % 1000 == 0 && i > 0) print('INC: $i completes');
     lastOffset = i;
     if (_SERVER_BASED_CALL) {
-      await withTimeOut(server.completeGet(source: src, offset: i));
+      SourceRequest request = SourceRequest()
+        ..source = src
+        ..offset = i;
+      await withTimeOut(server.complete(request));
     } else {
       await withTimeOut(wrapper.complete(src, i));
     }


### PR DESCRIPTION
- remove deprecated RESTful APIs

These are mostly the multi* APIs and the ones based on GET (instead of POST).

This clean-out is useful as we'll want to add new APIs (in support of exposing the Flutter UI refactorings from the analysis server).

After this lands, we'll need to copy the new `doc/generated/dartservices.dart` into the front end project.