### PR TITLE
 remove editor artifacts from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,5 @@ dump.rdb
 # compilation artifacts
 artifacts/
 
-# editor artifacts
-.vscode/
-.idea
-
 # local configuration
 config.properties


### PR DESCRIPTION
contributors should use .gitignore_global instead ([ref](https://github.com/dart-lang/dart-services/pull/413#issuecomment-497617831))