### PR TITLE
Dropping ignored strongMode arg from SourceRequest

### DIFF
--- a/doc/generated/dartservices.dart
+++ b/doc/generated/dartservices.dart
@@ -789,9 +789,6 @@ class SourceRequest {
   /// The Dart source.
   core.String source;
 
-  /// Ignored: always treated as true.
-  core.bool strongMode;
-
   SourceRequest();
 
   SourceRequest.fromJson(core.Map _json) {
@@ -800,9 +797,6 @@ class SourceRequest {
     }
     if (_json.containsKey("source")) {
       source = _json["source"];
-    }
-    if (_json.containsKey("strongMode")) {
-      strongMode = _json["strongMode"];
     }
   }
 
@@ -814,9 +808,6 @@ class SourceRequest {
     }
     if (source != null) {
       _json["source"] = source;
-    }
-    if (strongMode != null) {
-      _json["strongMode"] = strongMode;
     }
     return _json;
   }

--- a/doc/generated/dartservices.json
+++ b/doc/generated/dartservices.json
@@ -1,6 +1,6 @@
 {
  "kind": "discovery#restDescription",
- "etag": "8a41b61f09d0992f9a608a93fbffaa0e1953407b",
+ "etag": "9511ad5e62f9a85d39dbd491c411705fd3876af8",
  "discoveryVersion": "v1",
  "id": "dartservices:v1",
  "name": "dartservices",
@@ -26,10 +26,6 @@
      "type": "integer",
      "description": "An optional offset into the source code.",
      "format": "int32"
-    },
-    "strongMode": {
-     "type": "boolean",
-     "description": "Ignored: always treated as true."
     }
    }
   },

--- a/lib/src/api_classes.dart
+++ b/lib/src/api_classes.dart
@@ -62,10 +62,6 @@ class SourceRequest {
 
   @ApiProperty(description: 'An optional offset into the source code.')
   int offset;
-
-  @ApiProperty(description: 'Ignored: always treated as true.')
-  @deprecated
-  bool strongMode;
 }
 
 class SourcesRequest {


### PR DESCRIPTION
Dropping a legacy argument. I'm unsure what the requirements are around keeping the front end and back end in sync with this change. I'm guessing we need to copy this change to `dart-pad` and push that first, as the current backend treats the arg as optional. 