### PR TITLE
allow x-goog-api-client preflight header for local development

### DIFF
--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -182,7 +182,7 @@ Stack Trace: ${stackTrace.toString()}
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
       'Access-Control-Allow-Headers':
-          'Origin, X-Requested-With, Content-Type, Accept'
+          'Origin, X-Requested-With, Content-Type, Accept, x-goog-api-client'
     });
   }
 }


### PR DESCRIPTION
This only updates the local development server, not the production server