### PR TITLE
Update Discovery APIs Commons to 0.1.9

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _discoveryapis_commons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.8+1"
+    version: "0.1.9"
   analysis_server_lib:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.5.0 <3.0.0'
 
 dependencies:
-  _discoveryapis_commons: 0.1.8+1
+  _discoveryapis_commons: 0.1.9
   analyzer: ^0.38.0
   analysis_server_lib: ^0.1.4
   appengine: ^0.10.0


### PR DESCRIPTION
Running as http://20190917t075845-dot-dart-services.appspot.com/

/cc @johnpryan 