### PR TITLE
Upping minimum instances from 6 to 12.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -7,7 +7,7 @@ resources:
   disk_size_gb: 50
 
 automatic_scaling:
-  min_num_instances: 6
+  min_num_instances: 12
   max_num_instances: 40
   cool_down_period_sec: 60
   cpu_utilization:


### PR DESCRIPTION
I'm curious if this will improve our performance on access spikes. Right now every significant spike in usage sees a corresponding spike in 500s, and I'd like to know if it's tied to our need to create and warm up additional instances.