### PR TITLE
Updates flutter commit to latest dev channel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM google/dart:2.7.0
 # The specific commit that dart-services should use. This should be kept
 # in sync with the flutter submodule in the dart-services repo.
 # (run `git rev-parse HEAD` from the flutter submodule to retrieve this value.
-ARG FLUTTER_COMMIT=fbabb264e0ab3e090d6ec056e0744aaeb1586735
+ARG FLUTTER_COMMIT=4af66e335f8d87da5cb8c7f2a3e89c1ee02ef23b
 
 # We install unzip and remove the apt-index again to keep the
 # docker image diff small.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: appengine
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.3"
+    version: "0.10.4"
   args:
     dependency: "direct main"
     description:
@@ -525,7 +525,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   watcher:
     dependency: transitive
     description:

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -99,7 +99,7 @@ void defineTests() {
         expect(result.success, false);
         expect(result.problems.length, 1);
         expect(result.problems[0].toString(),
-            contains('[error] Expected to find \';\'.'));
+            contains('Error: Expected \';\' after this.'));
       });
     });
 
@@ -110,11 +110,11 @@ void defineTests() {
         expect(result.success, false);
         expect(result.problems.length, 1);
         expect(result.problems[0].toString(),
-            contains('[error] The function \'print1\' isn\'t defined.'));
+            contains('Error: Method not found: \'print1\'.'));
         expect(result.problems[0].toString(),
-            contains('[error] The function \'print2\' isn\'t defined.'));
+            contains('Error: Method not found: \'print2\'.'));
         expect(result.problems[0].toString(),
-            contains('[error] The function \'print3\' isn\'t defined.'));
+            contains('Error: Method not found: \'print3\'.'));
       });
     });
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -196,6 +196,47 @@ void _buildStorageArtifacts(Directory dir) {
 }
 
 @Task()
+void setupFlutterSubmodule() {
+  final flutterDir = Directory('flutter');
+
+  // Remove all files currently in the submodule. This is done to clear any
+  // internal state the Flutter/Dart SDKs may have created on their own.
+  flutterDir.listSync().forEach((e) => e.deleteSync(recursive: true));
+
+  // Pull clean files into the submodule, based on whatever commit it's set to.
+  run(
+    'git',
+    arguments: ['submodule', 'update'],
+  );
+
+  // Set up the submodule's copy of the Flutter SDK the way dart-services needs
+  // it.
+  run(
+    path.join(flutterDir.path, 'bin/flutter'),
+    arguments: ['doctor'],
+  );
+
+  run(
+    path.join(flutterDir.path, 'bin/flutter'),
+    arguments: ['config', '--enable-web'],
+  );
+
+  run(
+    path.join(flutterDir.path, 'bin/flutter'),
+    arguments: [
+      'precache',
+      '--web',
+      '--no-android',
+      '--no-ios',
+      '--no-linux',
+      '--no-windows',
+      '--no-macos',
+      '--no-fuchsia',
+    ],
+  );
+}
+
+@Task()
 void fuzz() {
   log('warning: fuzz testing is a noop, see #301');
 }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -155,7 +155,7 @@ void _buildStorageArtifacts(Directory dir) {
   );
 
   // Build the artifacts using DDC:
-  // dart-sdk/bin/dartdevc -k -s kernel/flutter_ddc_sdk.dill
+  // dart-sdk/bin/dartdevc -s kernel/flutter_ddc_sdk.dill
   //     --modules=amd package:flutter_web/animation.dart ...
   final compilerPath =
       path.join(flutterSdkPath.path, 'bin/cache/dart-sdk/bin/dartdevc');
@@ -163,7 +163,6 @@ void _buildStorageArtifacts(Directory dir) {
       'bin/cache/flutter_web_sdk/flutter_web_sdk/kernel/flutter_ddc_sdk.dill');
 
   var args = [
-    '-k',
     '-s',
     dillPath,
     '--modules=amd',


### PR DESCRIPTION
* Rolls new Flutter commit.
* Updates some tests to account for new analyzer responses.
* Works around the lack of `--single-out-file` in the new version of the Dart SDK.
* Adds a new grind task that blows away the Flutter submodule, recreates, and re-initalizes it. I had some trouble with weird internal state in the SDK submodule, and created this task as a way to "clean" the Flutter submodule.
