### PR TITLE
Adds analysis server-based healthcheck failure.

### DIFF
--- a/lib/src/common_server.dart
+++ b/lib/src/common_server.dart
@@ -268,6 +268,12 @@ class CommonServer {
   AnalysisServerWrapper analysisServer;
   AnalysisServerWrapper flutterAnalysisServer;
 
+  bool get analysisServersRunning => analysisServer.analysisServer != null &&
+    flutterAnalysisServer.analysisServer != null;
+
+  bool _running = false;
+  bool get running => _running;
+
   CommonServer(
     this.sdkPath,
     this.flutterWebManager,
@@ -313,6 +319,7 @@ class CommonServer {
     await compiler.warmup(useHtml: useHtml);
     await analysisServer.warmup(useHtml: useHtml);
     await flutterAnalysisServer.warmup(useHtml: useHtml);
+    _running = true;
   }
 
   Future<void> restart() async {
@@ -327,6 +334,7 @@ class CommonServer {
   }
 
   Future<dynamic> shutdown() {
+    _running = false;
     return Future.wait(<Future<dynamic>>[
       analysisServer.shutdown(),
       flutterAnalysisServer.shutdown(),

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -196,7 +196,7 @@ void _buildStorageArtifacts(Directory dir) {
       'artifacts/*.js gs://compilation_artifacts/$version/');
 }
 
-@Task()
+@Task('Delete, re-download, and reinitialize the Flutter submodule')
 void setupFlutterSubmodule() {
   final flutterDir = Directory('flutter');
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -196,7 +196,7 @@ void _buildStorageArtifacts(Directory dir) {
       'artifacts/*.js gs://compilation_artifacts/$version/');
 }
 
-@Task('Delete, re-download, and reinitialize the Flutter submodule')
+@Task('Delete, re-download, and reinitialize the Flutter submodule.')
 void setupFlutterSubmodule() {
   final flutterDir = Directory('flutter');
 


### PR DESCRIPTION
* Modifies CommonServer to expose two new properties
  - `analysisServersRunning` checks that the analysis server wrappers have valid references to running servers.
  - `running` is a manually set flag indicating whether the server is between calls to `warmup` and `shutdown`, during which it can be considered ready to receive requests.
* Modifies the GAE server class to fail a health check when CommonServer is running but its analysis servers aren't.

These changes are designed to mitigate this issue:

https://github.com/dart-lang/dart-pad/issues/1468