### PR TITLE
Enable editing dart-services in Gitpod.io

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -13,7 +13,7 @@ USER gitpod
 
 RUN sudo apt-get update
 RUN sudo apt-get install apt-transport-https
-RUN sudo apt install protobuf-compiler
+RUN sudo apt-get install protobuf-compiler
 RUN sudo apt-get install redis
 RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
 RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -16,4 +16,7 @@ RUN sudo apt-get update && \
  sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
  sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
  sudo apt-get update && \
- sudo apt-get install dart
+ sudo apt-get install dart && \
+ sudo echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> /etc/bash.bashrc && \
+ pub global activate grinder && \
+ pub global activate protoc_plugin

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -12,7 +12,7 @@ USER gitpod
 # More information: https://www.gitpod.io/docs/config-docker/
 
 RUN sudo apt-get update && \
- sudo apt-get install apt-transport-https && \
+ sudo apt-get install apt-transport-https redis && \
  sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
  sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
  sudo apt-get update && \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,12 +11,14 @@ USER gitpod
 #
 # More information: https://www.gitpod.io/docs/config-docker/
 
-RUN sudo apt-get update
-RUN sudo apt-get install apt-transport-https
-RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-RUN sudo apt-get update
-RUN sudo apt-get install dart
-RUN echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> $HOME/.bashrc
-RUN /usr/lib/dart/bin/pub global activate grinder
-RUN /usr/lib/dart/bin/pub global activate protoc_plugin
+RUN sudo apt-get update && \
+ sudo apt-get install apt-transport-https && \
+ sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
+ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
+ sudo apt-get update && \
+ sudo apt-get install dart && \
+ echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\":$PWD/protoc/bin" >> $HOME/.bashrc && \
+ /usr/lib/dart/bin/pub global activate grinder && \
+ /usr/lib/dart/bin/pub global activate protoc_plugin && \
+ wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip && \
+ unzip protoc-3.11.4-linux-x86_64.zip -d protoc

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -18,5 +18,5 @@ RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/l
 RUN sudo apt-get update
 RUN sudo apt-get install dart
 RUN echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> $HOME/.bashrc
-RUN pub global activate grinder
-RUN pub global activate protoc_plugin
+RUN /usr/lib/dart/bin/pub global activate grinder
+RUN /usr/lib/dart/bin/pub global activate protoc_plugin

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -13,7 +13,7 @@ USER gitpod
 
 RUN sudo apt-get update
 RUN sudo apt-get install apt-transport-https
-RUN sudo apt-get install protobuf
+RUN sudo apt install protobuf-compiler
 RUN sudo apt-get install redis
 RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
 RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,12 +11,12 @@ USER gitpod
 #
 # More information: https://www.gitpod.io/docs/config-docker/
 
-RUN sudo apt-get update && \
- sudo apt-get install apt-transport-https && \
- sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
- sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
- sudo apt-get update && \
- sudo apt-get install dart && \
- sudo echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> /etc/bash.bashrc && \
- pub global activate grinder && \
- pub global activate protoc_plugin
+RUN sudo apt-get update
+RUN sudo apt-get install apt-transport-https
+RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+RUN sudo apt-get update
+RUN sudo apt-get install dart
+RUN sudo echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> /etc/bash.bashrc
+RUN pub global activate grinder
+RUN pub global activate protoc_plugin

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -12,9 +12,9 @@ USER gitpod
 # More information: https://www.gitpod.io/docs/config-docker/
 
 RUN sudo apt-get update
-RUN sudo apt-get install apt-transport-https
-RUN sudo apt-get install protobuf-compiler
-RUN sudo apt-get install redis
+RUN sudo apt-get install -y apt-transport-https
+RUN sudo apt-get install -y protobuf-compiler
+RUN sudo apt-get install -y redis
 RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
 RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
 RUN sudo apt-get update

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,24 +3,17 @@ FROM gitpod/workspace-full
 USER gitpod
 
 # Install custom tools, runtime, etc. using apt-get
-# For example, the command below would install "bastet" - a command line tetris clone:
-#
-# RUN sudo apt-get -q update && \
-#     sudo apt-get install -yq bastet && \
-#     sudo rm -rf /var/lib/apt/lists/*
-#
 # More information: https://www.gitpod.io/docs/config-docker/
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y apt-transport-https
-RUN sudo apt-get install -y protobuf-compiler
-RUN sudo apt-get install -y redis
-RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-RUN sudo apt-get update
-RUN sudo apt-get install dart
-RUN echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\":$PWD/protoc/bin" >> $HOME/.bashrc
-RUN /usr/lib/dart/bin/pub global activate grinder
-RUN /usr/lib/dart/bin/pub global activate protoc_plugin
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
-RUN unzip protoc-3.11.4-linux-x86_64.zip -d protoc
+RUN sudo apt-get update && \
+    sudo apt-get install -y apt-transport-https protobuf-compiler redis && \
+    sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
+    sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
+    sudo apt-get update && \
+    sudo apt-get install dart && \
+    echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\":$PWD/protoc/bin" >> $HOME/.bashrc && \
+    /usr/lib/dart/bin/pub global activate grinder && \
+    /usr/lib/dart/bin/pub global activate protoc_plugin && \
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip && \
+    unzip protoc-3.11.4-linux-x86_64.zip -d protoc && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -17,6 +17,6 @@ RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub 
 RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
 RUN sudo apt-get update
 RUN sudo apt-get install dart
-RUN sudo echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> /etc/bash.bashrc
+RUN echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> $HOME/.bashrc
 RUN pub global activate grinder
 RUN pub global activate protoc_plugin

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,14 +11,14 @@ USER gitpod
 #
 # More information: https://www.gitpod.io/docs/config-docker/
 
-RUN sudo apt-get update && \
- sudo apt-get install apt-transport-https redis && \
- sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
- sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
- sudo apt-get update && \
- sudo apt-get install dart && \
- echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\":$PWD/protoc/bin" >> $HOME/.bashrc && \
- /usr/lib/dart/bin/pub global activate grinder && \
- /usr/lib/dart/bin/pub global activate protoc_plugin && \
- wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip && \
- unzip protoc-3.11.4-linux-x86_64.zip -d protoc
+RUN sudo apt-get update
+RUN sudo apt-get install apt-transport-https redis
+RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+RUN sudo apt-get update
+RUN sudo apt-get install dart
+RUN echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\":$PWD/protoc/bin" >> $HOME/.bashrc
+RUN /usr/lib/dart/bin/pub global activate grinder
+RUN /usr/lib/dart/bin/pub global activate protoc_plugin
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
+RUN unzip protoc-3.11.4-linux-x86_64.zip -d protoc

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,19 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+# RUN sudo apt-get -q update && \
+#     sudo apt-get install -yq bastet && \
+#     sudo rm -rf /var/lib/apt/lists/*
+#
+# More information: https://www.gitpod.io/docs/config-docker/
+
+RUN sudo apt-get update && \
+ sudo apt-get install apt-transport-https && \
+ sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
+ sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
+ sudo apt-get update && \
+ sudo apt-get install dart

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -12,7 +12,9 @@ USER gitpod
 # More information: https://www.gitpod.io/docs/config-docker/
 
 RUN sudo apt-get update
-RUN sudo apt-get install apt-transport-https redis
+RUN sudo apt-get install apt-transport-https
+RUN sudo apt-get install protobuf
+RUN sudo apt-get install redis
 RUN sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
 RUN sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
 RUN sudo apt-get update

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -14,6 +14,7 @@ RUN sudo apt-get update && \
     echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\":$PWD/protoc/bin" >> $HOME/.bashrc && \
     /usr/lib/dart/bin/pub global activate grinder && \
     /usr/lib/dart/bin/pub global activate protoc_plugin && \
+    /usr/lib/dart/bin/pub global activate webdev && \
     wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip && \
     unzip protoc-3.11.4-linux-x86_64.zip -d protoc && \
     sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -10,11 +10,9 @@ RUN sudo apt-get update && \
     sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
     sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
     sudo apt-get update && \
-    sudo apt-get install dart && \
-    echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\":$PWD/protoc/bin" >> $HOME/.bashrc && \
+    sudo apt-get install -y dart && \
+    echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> $HOME/.bashrc && \
     /usr/lib/dart/bin/pub global activate grinder && \
     /usr/lib/dart/bin/pub global activate protoc_plugin && \
     /usr/lib/dart/bin/pub global activate webdev && \
-    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip && \
-    unzip protoc-3.11.4-linux-x86_64.zip -d protoc && \
     sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+image:
+  file: .gitpod.Dockerfile
+
+# List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 3000
+    onOpen: open-preview
+
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: echo 'init script' # runs during prebuild
+    command: echo 'start script'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,9 +2,13 @@ image:
   file: .gitpod.Dockerfile
 
 # List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
-# ports:
-#   - port: 3000
-#     onOpen: open-preview
+ports:
+  - port: 8080
+    onOpen: "open-browser"
+  - port: 8082
+    onOpen: "ignore"
+  - port: 9501
+    onOpen: "ignore"
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,3 +13,8 @@ ports:
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
   - init: ./flutter/bin/flutter doctor -v && pub get && grind deploy
+
+# Add the DartCode extension. See https://www.gitpod.io/docs/vscode-extensions/
+vscode:
+  extensions:
+    - Dart-Code.dart-code@3.9.0:umvoqCQMs3NpksmwhVtStw==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,4 +8,4 @@ image:
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - init: flutter doctor -v && pub get && grind deploy
+  - init: ./flutter/bin/flutter doctor -v && pub get && grind deploy

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,11 +2,10 @@ image:
   file: .gitpod.Dockerfile
 
 # List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
-ports:
-  - port: 3000
-    onOpen: open-preview
+# ports:
+#   - port: 3000
+#     onOpen: open-preview
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - init: echo 'init script' # runs during prebuild
-    command: echo 'start script'
+  - init: flutter doctor -v && pub get && grind deploy

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A server backend to support DartPad.
 [![Build Status](https://travis-ci.org/dart-lang/dart-services.svg?branch=master)](https://travis-ci.org/dart-lang/dart-services)
 [![Coverage Status](https://coveralls.io/repos/dart-lang/dart-services/badge.svg?branch=master)](https://coveralls.io/r/dart-lang/dart-services?branch=master)
 [![Uptime Status](https://img.shields.io/badge/uptime-Pingdom-blue.svg)](http://stats.pingdom.com/8n3tfpl1u0j9)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/dart-lang/dart-services)
 
 ## What is it? What does it do?
 


### PR DESCRIPTION
Hey @RedBrogdon,

I'm investigating gitpod.io as an easy getting started development environment with zero required downloads. As a starting point, I added the following configuration to `dart-services` to make it possible to get started with developing on it easily. Let me know what you think =)

brett