### PR TITLE
Make gitpod's dart version explicit

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,7 +7,8 @@ USER gitpod
 
 RUN sudo apt-get update && \
     wget https://storage.googleapis.com/dart-archive/channels/stable/release/2.8.1/linux_packages/dart_2.8.1-1_amd64.deb && \
-    sudo apt-get install -f dart_2.8.1-1_amd64.deb && \
+    ls -l && \
+    sudo dpkg -i dart_2.8.1-1_amd64.deb && \
     sudo apt-get install -y protobuf-compiler redis && \
     sudo apt-get update && \
     echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> $HOME/.bashrc && \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,7 +7,6 @@ USER gitpod
 
 RUN sudo apt-get update && \
     wget https://storage.googleapis.com/dart-archive/channels/stable/release/2.8.1/linux_packages/dart_2.8.1-1_amd64.deb && \
-    ls -l && \
     sudo dpkg -i dart_2.8.1-1_amd64.deb && \
     sudo apt-get install -y protobuf-compiler redis && \
     sudo apt-get update && \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,11 +6,10 @@ USER gitpod
 # More information: https://www.gitpod.io/docs/config-docker/
 
 RUN sudo apt-get update && \
-    sudo apt-get install -y apt-transport-https protobuf-compiler redis && \
-    sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -' && \
-    sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list' && \
+    wget https://storage.googleapis.com/dart-archive/channels/stable/release/2.8.1/linux_packages/dart_2.8.1-1_amd64.deb && \
+    sudo apt-get install -f dart_2.8.1-1_amd64.deb && \
+    sudo apt-get install -y protobuf-compiler redis && \
     sudo apt-get update && \
-    sudo apt-get install -y dart && \
     echo "export PATH=\"\$PATH:/usr/lib/dart/bin:\$HOME/.pub-cache/bin\"" >> $HOME/.bashrc && \
     /usr/lib/dart/bin/pub global activate grinder && \
     /usr/lib/dart/bin/pub global activate protoc_plugin && \


### PR DESCRIPTION
TBR @johnpryan 

This is to work around Gitpod.io's implicit caching of the instance disk image. 