### PR TITLE
Enable https in warmup

### DIFF
--- a/tool/warmup.dart
+++ b/tool/warmup.dart
@@ -56,9 +56,10 @@ dart warmup.dart 20200124t152413-dot-dart-services-0.appspot.com
     exit(1);
   }
 
-  // Use an insecure connection for test driving to avoid cert problems
-  // with the prefixed app version.
-  uri = 'http://$appHost$BASE_PATH';
+  if (!appHost.startsWith('http://') && !appHost.startsWith('https://')) {
+    appHost = 'http://$appHost';
+  }
+  uri = '$appHost$BASE_PATH';
 
   print('Target URI\n$uri');
 


### PR DESCRIPTION
Turns out Cloud Run doesn't like http traffic (it 302's it across to https) unlike AppEngine Flex. Easy fix is to enable the warmup script to take both http and https urls to warmup.