### PR TITLE
Split AnalysisServerWrapper

### DIFF
--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -33,15 +33,14 @@ void main(List<String> args) async {
   });
 
   final benchmarks = <Benchmark>[
-    AnalyzerBenchmark('hello', sampleCode, flutterWebManager),
-    AnalyzerBenchmark('hellohtml', sampleCodeWeb, flutterWebManager),
-    AnalyzerBenchmark('sunflower', _sunflower, flutterWebManager),
-    AnalyzerBenchmark('spinning_square', _spinningSquare, flutterWebManager),
-    AnalysisServerBenchmark('hello', sampleCode, flutterWebManager),
-    AnalysisServerBenchmark('hellohtml', sampleCodeWeb, flutterWebManager),
-    AnalysisServerBenchmark('sunflower', _sunflower, flutterWebManager),
-    AnalysisServerBenchmark(
-        'spinning_square', _spinningSquare, flutterWebManager),
+    AnalyzerBenchmark('hello', sampleCode),
+    AnalyzerBenchmark('hellohtml', sampleCodeWeb),
+    AnalyzerBenchmark('sunflower', _sunflower),
+    AnalyzerBenchmark('spinning_square', _spinningSquare),
+    AnalysisServerBenchmark('hello', sampleCode),
+    AnalysisServerBenchmark('hellohtml', sampleCodeWeb),
+    AnalysisServerBenchmark('sunflower', _sunflower),
+    AnalysisServerBenchmark('spinning_square', _spinningSquare),
     Dart2jsBenchmark('hello', sampleCode, compiler),
     Dart2jsBenchmark('hellohtml', sampleCodeWeb, compiler),
     Dart2jsBenchmark('sunflower', _sunflower, compiler),
@@ -61,9 +60,10 @@ class AnalyzerBenchmark extends Benchmark {
   AnalysisServerWrapper analysisServer;
 
   AnalyzerBenchmark(
-      String name, this.source, FlutterWebManager flutterWebManager)
-      : super('analyzer.$name') {
-    analysisServer = AnalysisServerWrapper(sdkPath, flutterWebManager);
+    String name,
+    this.source,
+  ) : super('analyzer.$name') {
+    analysisServer = DartAnalysisServerWrapper();
   }
 
   @override
@@ -110,9 +110,8 @@ class AnalysisServerBenchmark extends Benchmark {
   final String source;
   final AnalysisServerWrapper analysisServer;
 
-  AnalysisServerBenchmark(
-      String name, this.source, FlutterWebManager flutterWebManager)
-      : analysisServer = AnalysisServerWrapper(sdkPath, flutterWebManager),
+  AnalysisServerBenchmark(String name, this.source)
+      : analysisServer = DartAnalysisServerWrapper(),
         super('completion.$name');
 
   @override

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -13,11 +13,9 @@ import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf;
 
-import 'src/common.dart';
 import 'src/common_server_api.dart';
 import 'src/common_server_impl.dart';
 import 'src/flutter_web.dart';
-import 'src/sdk_manager.dart';
 import 'src/server_cache.dart';
 import 'src/shelf_cors.dart' as shelf_cors;
 
@@ -36,22 +34,20 @@ void main(List<String> args) {
     exit(1);
   }
 
-  final sdk = sdkPath;
-
   Logger.root.level = Level.FINER;
   Logger.root.onRecord.listen((LogRecord record) {
     print(record);
     if (record.stackTrace != null) print(record.stackTrace);
   });
 
-  EndpointsServer.serve(sdk, port).then((EndpointsServer server) {
+  EndpointsServer.serve(port).then((EndpointsServer server) {
     _logger.info('Listening on port ${server.port}');
   });
 }
 
 class EndpointsServer {
-  static Future<EndpointsServer> serve(String sdkPath, int port) {
-    final endpointsServer = EndpointsServer._(sdkPath, port);
+  static Future<EndpointsServer> serve(int port) {
+    final endpointsServer = EndpointsServer._(port);
 
     return shelf
         .serve(endpointsServer.handler, InternetAddress.anyIPv4, port)
@@ -70,11 +66,8 @@ class EndpointsServer {
   CommonServerApi commonServerApi;
   FlutterWebManager flutterWebManager;
 
-  EndpointsServer._(String sdkPath, this.port) {
-    flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
+  EndpointsServer._(this.port) {
     final commonServerImpl = CommonServerImpl(
-      sdkPath,
-      flutterWebManager,
       _ServerContainer(),
       _Cache(),
     );

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -6,8 +6,6 @@ library services.common;
 
 import 'dart:io';
 
-import 'sdk_manager.dart';
-
 const kMainDart = 'main.dart';
 const kBootstrapDart = 'bootstrap.dart';
 
@@ -166,5 +164,3 @@ String stripMatchingQuotes(String str) {
   }
   return str;
 }
-
-String get sdkPath => SdkManager.sdk.sdkPath;

--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -24,9 +24,7 @@ class FlutterWebManager {
     _init();
   }
 
-  void dispose() {
-    _projectDirectory.deleteSync(recursive: true);
-  }
+  Future<void> dispose() => _projectDirectory.delete(recursive: true);
 
   Directory get projectDirectory => _projectDirectory;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   mime:
     dependency: transitive
     description:

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -62,12 +62,10 @@ void main() => defineTests();
 
 void defineTests() {
   AnalysisServerWrapper analysisServer;
-  FlutterWebManager flutterWebManager;
 
   group('Platform SDK analysis_server', () {
     setUp(() async {
-      flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-      analysisServer = AnalysisServerWrapper(sdkPath, flutterWebManager);
+      analysisServer = DartAnalysisServerWrapper();
       await analysisServer.init();
     });
 
@@ -191,10 +189,11 @@ void defineTests() {
   });
 
   group('Flutter cached SDK analysis_server', () {
+    FlutterWebManager flutterWebManager;
+
     setUp(() async {
       flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-      analysisServer = AnalysisServerWrapper(
-          SdkManager.flutterSdk.sdkPath, flutterWebManager);
+      analysisServer = FlutterAnalysisServerWrapper(flutterWebManager);
       await analysisServer.init();
     });
 

--- a/test/common_server_api_protobuf_test.dart
+++ b/test/common_server_api_protobuf_test.dart
@@ -10,8 +10,6 @@ import 'dart:convert';
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/common_server_impl.dart';
 import 'package:dart_services/src/common_server_api.dart';
-import 'package:dart_services/src/flutter_web.dart';
-import 'package:dart_services/src/sdk_manager.dart';
 import 'package:dart_services/src/server_cache.dart';
 import 'package:dart_services/src/protos/dart_services.pb.dart' as proto;
 import 'package:logging/logging.dart';
@@ -58,7 +56,6 @@ void main() => defineTests();
 void defineTests() {
   CommonServerApi commonServerApi;
   CommonServerImpl commonServerImpl;
-  FlutterWebManager flutterWebManager;
 
   MockContainer container;
   MockCache cache;
@@ -93,9 +90,7 @@ void defineTests() {
     setUpAll(() async {
       container = MockContainer();
       cache = MockCache();
-      flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-      commonServerImpl =
-          CommonServerImpl(sdkPath, flutterWebManager, container, cache);
+      commonServerImpl = CommonServerImpl(container, cache);
       commonServerApi = CommonServerApi(commonServerImpl);
       await commonServerImpl.init();
 

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -10,8 +10,6 @@ import 'dart:convert';
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/common_server_impl.dart';
 import 'package:dart_services/src/common_server_api.dart';
-import 'package:dart_services/src/flutter_web.dart';
-import 'package:dart_services/src/sdk_manager.dart';
 import 'package:dart_services/src/server_cache.dart';
 import 'package:logging/logging.dart';
 import 'package:mock_request/mock_request.dart';
@@ -58,7 +56,6 @@ void main() => defineTests();
 void defineTests() {
   CommonServerApi commonServerApi;
   CommonServerImpl commonServerImpl;
-  FlutterWebManager flutterWebManager;
 
   MockContainer container;
   MockCache cache;
@@ -93,9 +90,7 @@ void defineTests() {
     setUpAll(() async {
       container = MockContainer();
       cache = MockCache();
-      flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-      commonServerImpl =
-          CommonServerImpl(sdkPath, flutterWebManager, container, cache);
+      commonServerImpl = CommonServerImpl(container, cache);
       commonServerApi = CommonServerApi(commonServerImpl);
       await commonServerImpl.init();
 

--- a/test/flutter_analysis_server_test.dart
+++ b/test/flutter_analysis_server_test.dart
@@ -211,8 +211,7 @@ void defineTests() {
       await SdkManager.flutterSdk.init();
       flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
       await flutterWebManager.warmup();
-      analysisServer = AnalysisServerWrapper(
-          SdkManager.flutterSdk.sdkPath, flutterWebManager);
+      analysisServer = FlutterAnalysisServerWrapper(flutterWebManager);
       await analysisServer.init();
       await analysisServer.warmup();
     });
@@ -247,8 +246,7 @@ void defineTests() {
           Compiler(SdkManager.sdk, SdkManager.flutterSdk, flutterWebManager);
       await compiler.warmup();
 
-      analysisServer = AnalysisServerWrapper(
-          SdkManager.flutterSdk.sdkPath, flutterWebManager);
+      analysisServer = FlutterAnalysisServerWrapper(flutterWebManager);
       await analysisServer.init();
       await analysisServer.warmup();
     });
@@ -280,13 +278,11 @@ void defineTests() {
       flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
       await flutterWebManager.warmup();
 
-      flutterAnalysisServer = AnalysisServerWrapper(
-          SdkManager.flutterSdk.sdkPath, flutterWebManager);
+      flutterAnalysisServer = FlutterAnalysisServerWrapper(flutterWebManager);
       await flutterAnalysisServer.init();
       await flutterAnalysisServer.warmup();
 
-      dartAnalysisServer =
-          AnalysisServerWrapper(SdkManager.sdk.sdkPath, flutterWebManager);
+      dartAnalysisServer = DartAnalysisServerWrapper();
       await dartAnalysisServer.init();
       await dartAnalysisServer.warmup();
     });
@@ -310,7 +306,6 @@ void defineTests() {
 
   group('CommonServerImpl flutter analyze', () {
     CommonServerImpl commonServerImpl;
-    FlutterWebManager flutterWebManager;
 
     _MockContainer container;
     _MockCache cache;
@@ -319,24 +314,21 @@ void defineTests() {
       await SdkManager.flutterSdk.init();
       container = _MockContainer();
       cache = _MockCache();
-      flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-      commonServerImpl =
-          CommonServerImpl(sdkPath, flutterWebManager, container, cache);
+      commonServerImpl = CommonServerImpl(container, cache);
       await commonServerImpl.init();
     });
 
     tearDown(() async {
       await commonServerImpl.shutdown();
-      await flutterWebManager.dispose();
     });
 
-    test('analyze counter app', () async {
+    test('counter app', () async {
       final results =
           await commonServerImpl.analyze(SourceRequest()..source = counter);
       expect(results.issues, isEmpty);
     });
 
-    test('analyze Draggable Physics sample', () async {
+    test('Draggable Physics sample', () async {
       final results = await commonServerImpl
           .analyze(SourceRequest()..source = draggableAndPhysics);
       expect(results.issues, isEmpty);

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -64,7 +64,6 @@ Usage: slow_test path_to_test_collection
   if (args.length >= 4) iterations = int.parse(args[3]);
   if (args.length >= 5) commandToRun = args[4];
   if (args.length >= 6) dumpServerComms = args[5].toLowerCase() == 'true';
-  final sdk = sdkPath;
 
   // Load the list of files.
   var fileEntities = <io.FileSystemEntity>[];
@@ -81,10 +80,10 @@ Usage: slow_test path_to_test_collection
   final sw = Stopwatch()..start();
 
   print('About to setuptools');
-  print(sdk);
+  print(SdkManager.sdk.sdkPath);
 
   // Warm up the services.
-  await setupTools(sdk);
+  await setupTools(SdkManager.sdk.sdkPath);
 
   print('Setup tools done');
 
@@ -106,7 +105,7 @@ Usage: slow_test path_to_test_collection
       print('FAILED: ${fse.path}');
 
       // Try and re-cycle the services for the next test after the crash
-      await setupTools(sdk);
+      await setupTools(SdkManager.sdk.sdkPath);
     }
   }
 
@@ -127,12 +126,10 @@ Future setupTools(String sdkPath) async {
 
   container = MockContainer();
   cache = MockCache();
-  commonServerImpl =
-      CommonServerImpl(sdkPath, flutterWebManager, container, cache);
+  commonServerImpl = CommonServerImpl(container, cache);
   await commonServerImpl.init();
 
-  analysisServer =
-      analysis_server.AnalysisServerWrapper(sdkPath, flutterWebManager);
+  analysisServer = analysis_server.DartAnalysisServerWrapper();
   await analysisServer.init();
 
   print('Warming up analysis server');


### PR DESCRIPTION
Split `AnalysisServerWrapper` into Dart and Flutter variants, and also make `FlutterWebManager` the sole responsibility of `CommonServerImpl`.