### PR TITLE
Giving Analysis Servers it's own FlutterWebManager

### DIFF
--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -13,18 +13,13 @@ import 'package:dart_services/src/analysis_server.dart';
 import 'package:dart_services/src/bench.dart';
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/compiler.dart';
-import 'package:dart_services/src/flutter_web.dart';
 
 void main(List<String> args) async {
   final json = args.contains('--json');
 
   final harness = BenchmarkHarness(asJson: json);
 
-  final flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-  await flutterWebManager.warmup();
-
-  final compiler =
-      Compiler(SdkManager.sdk, SdkManager.flutterSdk, flutterWebManager);
+  final compiler = Compiler(SdkManager.sdk, SdkManager.flutterSdk);
 
   Logger.root.level = Level.WARNING;
   Logger.root.onRecord.listen((LogRecord record) {

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -58,7 +58,7 @@ class AnalysisServersWrapper {
   bool get isHealthy => (_restartingSince == null ||
       DateTime.now().difference(_restartingSince).inMinutes < 30);
 
-  Future<void> init() async {
+  Future<void> warmup() async {
     _logger.info('Beginning AnalysisServersWrapper init().');
     _dartAnalysisServer = DartAnalysisServerWrapper();
     _flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
@@ -85,6 +85,12 @@ class AnalysisServersWrapper {
     }));
 
     _restartingSince = null;
+
+    return Future.wait(<Future<dynamic>>[
+      _flutterWebManager.warmup(),
+      _flutterAnalysisServer.warmup(),
+      _dartAnalysisServer.warmup(),
+    ]);
   }
 
   Future<void> _restart() async {
@@ -92,16 +98,9 @@ class AnalysisServersWrapper {
     await shutdown();
     _logger.info('shutdown');
 
-    await init();
     await warmup();
     _logger.warning('Restart complete');
   }
-
-  Future warmup() => Future.wait(<Future<dynamic>>[
-        _flutterWebManager.warmup(),
-        _flutterAnalysisServer.warmup(),
-        _dartAnalysisServer.warmup(),
-      ]);
 
   Future<dynamic> shutdown() {
     _restartingSince = DateTime.now();

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -15,6 +15,7 @@ import 'package:path/path.dart' as path;
 import 'package:pedantic/pedantic.dart';
 
 import 'common.dart';
+import 'common_server_impl.dart' show BadRequest;
 import 'flutter_web.dart';
 import 'protos/dart_services.pb.dart' as proto;
 import 'pub.dart';
@@ -35,9 +36,9 @@ const String _WARMUP_SRC = 'main() { int b = 2;  b++;   b. }';
 const Duration _ANALYSIS_SERVER_TIMEOUT = Duration(seconds: 35);
 
 class AnalysisServersWrapper {
-  AnalysisServersWrapper(this._flutterWebManager);
+  AnalysisServersWrapper();
 
-  final FlutterWebManager _flutterWebManager;
+  FlutterWebManager _flutterWebManager;
   DartAnalysisServerWrapper _dartAnalysisServer;
   FlutterAnalysisServerWrapper _flutterAnalysisServer;
 
@@ -60,6 +61,7 @@ class AnalysisServersWrapper {
   Future<void> init() async {
     _logger.info('Beginning AnalysisServersWrapper init().');
     _dartAnalysisServer = DartAnalysisServerWrapper();
+    _flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
     _flutterAnalysisServer = FlutterAnalysisServerWrapper(_flutterWebManager);
 
     await _dartAnalysisServer.init();
@@ -85,7 +87,18 @@ class AnalysisServersWrapper {
     _restartingSince = null;
   }
 
+  Future<void> _restart() async {
+    _logger.warning('Restarting');
+    await shutdown();
+    _logger.info('shutdown');
+
+    await init();
+    await warmup();
+    _logger.warning('Restart complete');
+  }
+
   Future warmup() => Future.wait(<Future<dynamic>>[
+        _flutterWebManager.warmup(),
         _flutterAnalysisServer.warmup(),
         _dartAnalysisServer.warmup(),
       ]);
@@ -94,8 +107,9 @@ class AnalysisServersWrapper {
     _restartingSince = DateTime.now();
 
     return Future.wait(<Future<dynamic>>[
-      _dartAnalysisServer.shutdown(),
+      _flutterWebManager.dispose(),
       _flutterAnalysisServer.shutdown(),
+      _dartAnalysisServer.shutdown(),
     ]);
   }
 
@@ -106,23 +120,71 @@ class AnalysisServersWrapper {
         : _dartAnalysisServer;
   }
 
-  Future<proto.AnalysisResults> analyze(String source) =>
-      _getCorrectAnalysisServer(source).analyze(source);
+  Future<proto.AnalysisResults> analyze(String source) => _perfLogAndRestart(
+      source,
+      () => _getCorrectAnalysisServer(source).analyze(source),
+      'analysis',
+      'Error during analyze on "$source"');
 
   Future<proto.CompleteResponse> complete(String source, int offset) =>
-      _getCorrectAnalysisServer(source).complete(source, offset);
+      _perfLogAndRestart(
+          source,
+          () => _getCorrectAnalysisServer(source).complete(source, offset),
+          'completions',
+          'Error during complete on "$source" at $offset');
 
   Future<proto.FixesResponse> getFixes(String source, int offset) =>
-      _getCorrectAnalysisServer(source).getFixes(source, offset);
+      _perfLogAndRestart(
+          source,
+          () => _getCorrectAnalysisServer(source).getFixes(source, offset),
+          'fixes',
+          'Error during fixes on "$source" at $offset');
 
   Future<proto.AssistsResponse> getAssists(String source, int offset) =>
-      _getCorrectAnalysisServer(source).getAssists(source, offset);
+      _perfLogAndRestart(
+          source,
+          () => _getCorrectAnalysisServer(source).getAssists(source, offset),
+          'assists',
+          'Error during assists on "$source" at $offset');
 
   Future<proto.FormatResponse> format(String source, int offset) =>
-      _getCorrectAnalysisServer(source).format(source, offset);
+      _perfLogAndRestart(
+          source,
+          () => _getCorrectAnalysisServer(source).format(source, offset),
+          'format',
+          'Error during format on "$source" at $offset');
 
   Future<Map<String, String>> dartdoc(String source, int offset) =>
-      _getCorrectAnalysisServer(source).dartdoc(source, offset);
+      _perfLogAndRestart(
+          source,
+          () => _getCorrectAnalysisServer(source).dartdoc(source, offset),
+          'dartdoc',
+          'Error during dartdoc on "$source" at $offset');
+
+  Future<T> _perfLogAndRestart<T>(String source, Future<T> Function() body,
+      String action, String errorDescription) async {
+    await _checkPackageReferences(source);
+    try {
+      final watch = Stopwatch()..start();
+      final response = await body();
+      _logger.info('PERF: Computed $action in ${watch.elapsedMilliseconds}ms.');
+      return response;
+    } catch (e, st) {
+      _logger.severe(errorDescription, e, st);
+      await _restart();
+      rethrow;
+    }
+  }
+
+  /// Check that the set of packages referenced is valid.
+  Future<void> _checkPackageReferences(String source) async {
+    final imports = getAllImportsFor(source);
+
+    if (_flutterWebManager.hasUnsupportedImport(imports)) {
+      throw BadRequest(
+          'Unsupported input: ${_flutterWebManager.getUnsupportedImport(imports)}');
+    }
+  }
 }
 
 class DartAnalysisServerWrapper extends AnalysisServerWrapper {

--- a/lib/src/common_server_impl.dart
+++ b/lib/src/common_server_impl.dart
@@ -36,7 +36,6 @@ class CommonServerImpl {
   final ServerContainer container;
   final ServerCache cache;
 
-  // FlutterWebManager flutterWebManager;
   Compiler compiler;
   AnalysisServersWrapper analysisServers;
 

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -188,7 +188,10 @@ class Compiler {
     }
   }
 
-  Future<void> dispose() => _ddcDriver.terminateWorkers();
+  Future<void> dispose() async {
+    await _flutterWebManager.dispose();
+    return _ddcDriver.terminateWorkers();
+  }
 }
 
 /// The result of a dart2js compile.

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -28,20 +28,22 @@ class Compiler {
   final String _dartdevcPath;
   final BazelWorkerDriver _ddcDriver;
 
-  Compiler(this._sdk, this._flutterSdk, this._flutterWebManager)
+  Compiler(this._sdk, this._flutterSdk)
       : _dartdevcPath = path.join(_flutterSdk.sdkPath, 'bin', 'dartdevc'),
         _ddcDriver = BazelWorkerDriver(
             () => Process.start(
                   path.join(_flutterSdk.sdkPath, 'bin', 'dartdevc'),
                   <String>['--persistent_worker'],
                 ),
-            maxWorkers: 1);
+            maxWorkers: 1),
+        _flutterWebManager = FlutterWebManager(_flutterSdk);
 
   bool importsOkForCompile(Set<String> imports) {
     return !_flutterWebManager.hasUnsupportedImport(imports);
   }
 
-  Future<CompilationResults> warmup({bool useHtml = false}) {
+  Future<CompilationResults> warmup({bool useHtml = false}) async {
+    await _flutterWebManager.warmup();
     return compile(useHtml ? sampleCodeWeb : sampleCode);
   }
 

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -6,7 +6,6 @@ library services.compiler_test;
 
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/compiler.dart';
-import 'package:dart_services/src/flutter_web.dart';
 import 'package:dart_services/src/sdk_manager.dart';
 import 'package:test/test.dart';
 
@@ -14,18 +13,14 @@ void main() => defineTests();
 
 void defineTests() {
   Compiler compiler;
-  FlutterWebManager flutterWebManager;
 
   group('compiler', () {
     setUpAll(() async {
       await SdkManager.sdk.init();
       await SdkManager.flutterSdk.init();
 
-      flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-      await flutterWebManager.warmup();
-
-      compiler =
-          Compiler(SdkManager.sdk, SdkManager.flutterSdk, flutterWebManager);
+      compiler = Compiler(SdkManager.sdk, SdkManager.flutterSdk);
+      await compiler.warmup();
     });
 
     tearDownAll(() async {

--- a/test/flutter_analysis_server_test.dart
+++ b/test/flutter_analysis_server_test.dart
@@ -233,21 +233,17 @@ void defineTests() {
 
   group('Flutter SDK analysis_server with analysis servers', () {
     AnalysisServersWrapper analysisServersWrapper;
-    FlutterWebManager flutterWebManager;
 
     setUp(() async {
       await SdkManager.flutterSdk.init();
-      flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-      await flutterWebManager.warmup();
 
-      analysisServersWrapper = AnalysisServersWrapper(flutterWebManager);
+      analysisServersWrapper = AnalysisServersWrapper();
       await analysisServersWrapper.init();
       await analysisServersWrapper.warmup();
     });
 
     tearDown(() async {
       await analysisServersWrapper.shutdown();
-      await flutterWebManager.dispose();
     });
 
     test('analyze counter app', () async {

--- a/test/flutter_analysis_server_test.dart
+++ b/test/flutter_analysis_server_test.dart
@@ -238,7 +238,6 @@ void defineTests() {
       await SdkManager.flutterSdk.init();
 
       analysisServersWrapper = AnalysisServersWrapper();
-      await analysisServersWrapper.init();
       await analysisServersWrapper.warmup();
     });
 

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -16,7 +16,6 @@ import 'package:dart_services/src/analysis_server.dart' as analysis_server;
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/common_server_impl.dart';
 import 'package:dart_services/src/compiler.dart' as comp;
-import 'package:dart_services/src/flutter_web.dart';
 import 'package:dart_services/src/sdk_manager.dart';
 import 'package:dart_services/src/server_cache.dart';
 import 'package:dart_services/src/protos/dart_services.pb.dart' as proto;
@@ -122,8 +121,6 @@ Future setupTools(String sdkPath) async {
 
   print('SdKPath: $sdkPath');
 
-  final flutterWebManager = FlutterWebManager(SdkManager.flutterSdk);
-
   container = MockContainer();
   cache = MockCache();
   commonServerImpl = CommonServerImpl(container, cache);
@@ -136,8 +133,7 @@ Future setupTools(String sdkPath) async {
   await analysisServer.warmup();
 
   print('Warming up compiler');
-  compiler =
-      comp.Compiler(SdkManager.sdk, SdkManager.flutterSdk, flutterWebManager);
+  compiler = comp.Compiler(SdkManager.sdk, SdkManager.flutterSdk);
   await compiler.warmup();
   print('SetupTools done');
 }


### PR DESCRIPTION
I suspect having the FlutterWebManager project shared between two analyzers and two compiler toolchains is confusing things.