### PR TITLE
Drop beta channel from CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [stable, beta]
+        sdk: [stable]
     steps:
       - uses: actions/checkout@v2
       - uses: cedx/setup-dart@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ install:
 dart:
   # Keep this value aligned with min SDK value in pubspec.yaml and FROM line of Dockerfile
   - "2.10.4"
-  - beta
 
 # Use Ubuntu 18.04 (Bionic Beaver) 
 # https://docs.travis-ci.com/user/reference/overview/#virtualization-environments


### PR DESCRIPTION
Dart `beta` is now 2.12, and this requires changing tests for Dart Null Safety, per #614