### PR TITLE
Changes required to push to prod

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,5 @@
-include: package:pedantic/analysis_options.1.9.0.yaml
+# Dart analyzer dislikes this line. https://github.com/dart-lang/dart-pad/issues/1720
+# include: package:pedantic/analysis_options.1.9.0.yaml
 
 analyzer:
   strong-mode:
@@ -7,7 +8,7 @@ analyzer:
     - dart-sdk/**
     - doc/generated/**
     - flutter/**
-    # TODO: This seems to be hiding ~2 dozen legitimate analysis issues.
+    # TODO: This seems to be hiding ~2 dozen legitimate analysis issues. https://github.com/dart-lang/dart-pad/issues/1712
     - lib/src/protos/**
 
 linter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -463,6 +463,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.4"
+  shelf_router_generator:
+    dependency: "direct dev"
+    description:
+      name: shelf_router_generator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.2+3"
   shelf_static:
     dependency: transitive
     description:
@@ -477,6 +484,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.3"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.10+1"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dev_dependencies:
   grinder: ^0.8.0
   mock_request: ^1.0.7
   pedantic: ^1.9.0
+  shelf_router_generator: ^0.7.0+1
   synchronized: ^2.1.0
   test: ^1.6.4
 


### PR DESCRIPTION
These changes were required to be able to push a release to prod on AppEngine Flex. This reverses out part of https://github.com/dart-lang/dart-services/pull/630