### PR TITLE
Mark other VM imports as unsupported

### DIFF
--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -24,9 +24,16 @@ class FlutterWebManager {
     return path.join('artifacts', 'flutter_web.dill');
   }
 
-  static final Set<String> _flutterWebImportPrefixes = <String>{
+  static const Set<String> _flutterWebImportPrefixes = {
     'package:flutter',
     'dart:ui',
+  };
+
+  static const Set<String> _dartVmImports = {
+    'dart:ffi',
+    'dart:io',
+    'dart:isolate',
+    'dart:mirrors',
   };
 
   bool usesFlutterWeb(Set<String> imports) {
@@ -43,8 +50,8 @@ class FlutterWebManager {
 
   String getUnsupportedImport(Set<String> imports) {
     for (final import in imports) {
-      // All dart: imports are ok, except dart:io
-      if (import.startsWith('dart:') && import != 'dart:io') {
+      // All non-VM dart: imports are ok
+      if (import.startsWith('dart:') && !_dartVmImports.contains(import)) {
         continue;
       }
 

--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -29,11 +29,22 @@ class FlutterWebManager {
     'dart:ui',
   };
 
-  static const Set<String> _dartVmImports = {
-    'dart:ffi',
-    'dart:io',
-    'dart:isolate',
-    'dart:mirrors',
+  static const Set<String> _allowedDartImports = {
+    'dart:async',
+    'dart:collection',
+    'dart:convert',
+    'dart:core',
+    'dart:developer',
+    'dart:math',
+    'dart:typed_data',
+    'dart:html',
+    'dart:indexed_db',
+    'dart:js',
+    'dart:js_util',
+    'dart:svg',
+    'dart:web_audio',
+    'dart:web_gl',
+    'dart:web_sql',
   };
 
   bool usesFlutterWeb(Set<String> imports) {
@@ -51,7 +62,7 @@ class FlutterWebManager {
   String getUnsupportedImport(Set<String> imports) {
     for (final import in imports) {
       // All non-VM dart: imports are ok
-      if (import.startsWith('dart:') && !_dartVmImports.contains(import)) {
+      if (import.startsWith('dart:') && _allowedDartImports.contains(import)) {
         continue;
       }
 

--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -47,6 +47,7 @@ class FlutterWebManager {
     'dart:web_audio',
     'dart:web_gl',
     'dart:web_sql',
+    'dart:ui',
   };
 
   bool usesFlutterWeb(Set<String> imports) {

--- a/lib/src/flutter_web.dart
+++ b/lib/src/flutter_web.dart
@@ -29,6 +29,8 @@ class FlutterWebManager {
     'dart:ui',
   };
 
+  /// A set of all allowed `dart:` imports. Currently includes non-VM libraries
+  /// listed as the [doc](https://api.dart.dev/stable/index.html) categories.
   static const Set<String> _allowedDartImports = {
     'dart:async',
     'dart:collection',


### PR DESCRIPTION
None of these have runtime support on web platforms, similar to `dart:io`.