### PR TITLE
Enforce two strict analysis modes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,9 @@
 # include: package:pedantic/analysis_options.1.9.0.yaml
 
 analyzer:
+  language:
+    strict-inference: true
+    strict-raw-types: true
   strong-mode:
     implicit-casts: false
   exclude:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,6 @@
 
 analyzer:
   language:
-    strict-inference: true
     strict-raw-types: true
   strong-mode:
     implicit-casts: false

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -6,10 +6,12 @@ library services.bench;
 
 import 'dart:async';
 
+import 'package:analysis_server_lib/analysis_server_lib.dart';
 import 'package:dart_services/src/analysis_server.dart';
 import 'package:dart_services/src/bench.dart';
 import 'package:dart_services/src/common.dart';
 import 'package:dart_services/src/compiler.dart';
+import 'package:dart_services/src/protos/dart_services.pb.dart' as proto;
 import 'package:dart_services/src/sdk_manager.dart';
 import 'package:logging/logging.dart';
 
@@ -61,13 +63,13 @@ class AnalyzerBenchmark extends Benchmark {
   }
 
   @override
-  Future init() => analysisServer.init();
+  Future<AnalysisServer> init() => analysisServer.init();
 
   @override
-  Future perform() => analysisServer.analyze(source);
+  Future<proto.AnalysisResults> perform() => analysisServer.analyze(source);
 
   @override
-  Future tearDown() => analysisServer.shutdown();
+  Future<dynamic> tearDown() => analysisServer.shutdown();
 }
 
 class Dart2jsBenchmark extends Benchmark {
@@ -78,7 +80,7 @@ class Dart2jsBenchmark extends Benchmark {
       : super('dart2js.$name');
 
   @override
-  Future perform() {
+  Future<void> perform() {
     return compiler.compile(source).then((CompilationResults result) {
       if (!result.success) throw result;
     });
@@ -93,7 +95,7 @@ class DevCompilerBenchmark extends Benchmark {
       : super('dartdevc.$name');
 
   @override
-  Future perform() {
+  Future<void> perform() {
     return compiler.compileDDC(source).then((DDCCompilationResults result) {
       if (!result.success) throw result;
     });
@@ -109,13 +111,14 @@ class AnalysisServerBenchmark extends Benchmark {
         super('completion.$name');
 
   @override
-  Future init() => analysisServer.init();
+  Future<AnalysisServer> init() => analysisServer.init();
 
   @override
-  Future perform() => analysisServer.complete(source, 30);
+  Future<proto.CompleteResponse> perform() =>
+      analysisServer.complete(source, 30);
 
   @override
-  Future tearDown() => analysisServer.shutdown();
+  Future<dynamic> tearDown() => analysisServer.shutdown();
 }
 
 final String _sunflower = '''

--- a/lib/services_gae.dart
+++ b/lib/services_gae.dart
@@ -126,7 +126,7 @@ class GaeServer {
     await request.response.close();
   }
 
-  Future _processReadinessRequest(io.HttpRequest request) async {
+  Future<void> _processReadinessRequest(io.HttpRequest request) async {
     _logger.info('Processing readiness check');
     if (proxying) {
       request.response.statusCode = io.HttpStatus.ok;
@@ -141,7 +141,7 @@ class GaeServer {
     await request.response.close();
   }
 
-  Future _processLivenessRequest(io.HttpRequest request) async {
+  Future<void> _processLivenessRequest(io.HttpRequest request) async {
     _logger.info('Processing liveness check');
     if (proxying) {
       request.response.statusCode = io.HttpStatus.ok;
@@ -179,7 +179,7 @@ class GaeServer {
     await request.response.close();
   }
 
-  Future _processDefaultRequest(io.HttpRequest request) async {
+  Future<void> _processDefaultRequest(io.HttpRequest request) async {
     request.response.statusCode = io.HttpStatus.notFound;
     await request.response.close();
   }

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -56,7 +56,7 @@ class DartAnalysisServerWrapper extends AnalysisServerWrapper {
   }
 
   @override
-  Future shutdown() {
+  Future<dynamic> shutdown() {
     _logger.info('DartAnalysisServerWrapper shutdown');
     return _tempProject
         .delete(recursive: true)
@@ -86,7 +86,7 @@ class FlutterAnalysisServerWrapper extends AnalysisServerWrapper {
   }
 
   @override
-  Future shutdown() {
+  Future<dynamic> shutdown() {
     _logger.info('FlutterAnalysisServerWrapper shutdown');
     return super.shutdown();
   }
@@ -149,8 +149,9 @@ abstract class AnalysisServerWrapper {
         await _sendRemoveOverlays();
 
         return analysisServer;
-      }).catchError((err, st) {
+      }).catchError((Object err, StackTrace st) {
         _logger.severe('Error starting analysis server ($sdkPath): $err.\n$st');
+        return null;
       });
     }
 

--- a/lib/src/common_server_impl.dart
+++ b/lib/src/common_server_impl.dart
@@ -137,7 +137,7 @@ class CommonServerImplProxy implements CommonServerImpl {
   bool get isRestarting => false;
 
   @override
-  Future shutdown() => null;
+  Future<dynamic> shutdown() => null;
 
   @override
   AnalysisServersWrapper get _analysisServers => null;

--- a/lib/src/server_cache.dart
+++ b/lib/src/server_cache.dart
@@ -122,7 +122,7 @@ class RedisCache implements ServerCache {
           });
         })
         .timeout(const Duration(milliseconds: _connectionRetryMaxMs))
-        .catchError((_) {
+        .catchError((Object _) {
           log.severe(
               '$_logPrefix: Unable to connect to redis server, reconnecting in ${nextRetryMs}ms ...');
           Future<void>.delayed(Duration(milliseconds: nextRetryMs)).then((_) {

--- a/test/bench_test.dart
+++ b/test/bench_test.dart
@@ -44,7 +44,7 @@ class MockBenchmark extends Benchmark {
   MockBenchmark() : super('mock');
 
   @override
-  Future perform() {
+  Future<void> perform() {
     count++;
     return Future.delayed(Duration(milliseconds: 10));
   }

--- a/test/common_server_api_protobuf_test.dart
+++ b/test/common_server_api_protobuf_test.dart
@@ -100,7 +100,7 @@ void defineTests() {
       // TODO(jcollins-g): determine which piece of initialization isn't
       // happening and deal with that in warmup/init.
       {
-        var decodedJson = {};
+        var decodedJson = <dynamic, dynamic>{};
         final jsonData = proto.SourceRequest()..source = sampleCodeError;
         while (decodedJson.isEmpty) {
           final response =
@@ -409,10 +409,11 @@ class MockCache implements ServerCache {
   Future<String> get(String key) => Future.value(null);
 
   @override
-  Future set(String key, String value, {Duration expiration}) => Future.value();
+  Future<void> set(String key, String value, {Duration expiration}) =>
+      Future.value();
 
   @override
-  Future remove(String key) => Future.value();
+  Future<void> remove(String key) => Future.value();
 
   @override
   Future<void> shutdown() => Future.value();

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -285,7 +285,7 @@ void defineTests() {
       // TODO(jcollins-g): determine which piece of initialization isn't
       // happening and deal with that in warmup/init.
       {
-        var decodedJson = {};
+        var decodedJson = <dynamic, dynamic>{};
         final jsonData = {'source': sampleCodeError};
         while (decodedJson.isEmpty) {
           final response =
@@ -318,7 +318,7 @@ void defineTests() {
             await _sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 200);
         final data = await response.transform(utf8.decoder).join();
-        expect(json.decode(data), {});
+        expect(json.decode(data), <dynamic, dynamic>{});
       }
     });
 
@@ -389,7 +389,7 @@ void defineTests() {
 
     test('analyze negative-test noSource', () async {
       for (final version in versions) {
-        final jsonData = {};
+        final jsonData = <dynamic, dynamic>{};
         final response =
             await _sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 400);
@@ -421,7 +421,7 @@ void defineTests() {
 
     test('compile negative-test noSource', () async {
       for (final version in versions) {
-        final jsonData = {};
+        final jsonData = <dynamic, dynamic>{};
         final response =
             await _sendPostRequest('dartservices/$version/compile', jsonData);
         expect(response.statusCode, 400);
@@ -452,8 +452,8 @@ void defineTests() {
 
     test('complete no data', () async {
       for (final version in versions) {
-        final response =
-            await _sendPostRequest('dartservices/$version/complete', {});
+        final response = await _sendPostRequest(
+            'dartservices/$version/complete', <dynamic, dynamic>{});
         expect(response.statusCode, 400);
       }
     });
@@ -500,7 +500,7 @@ void defineTests() {
         expect(response.statusCode, 200);
         final data = json.decode(await response.transform(utf8.decoder).join());
         expect(data, {
-          'info': {},
+          'info': <dynamic, dynamic>{},
         });
       }
     });
@@ -515,7 +515,7 @@ void defineTests() {
             await _sendPostRequest('dartservices/$version/document', jsonData);
         expect(response.statusCode, 200);
         final data = json.decode(await response.transform(utf8.decoder).join());
-        expect(data, {'info': {}});
+        expect(data, {'info': <dynamic, dynamic>{}});
       }
     });
 
@@ -662,10 +662,11 @@ class MockCache implements ServerCache {
   Future<String> get(String key) => Future.value(null);
 
   @override
-  Future set(String key, String value, {Duration expiration}) => Future.value();
+  Future<void> set(String key, String value, {Duration expiration}) =>
+      Future.value();
 
   @override
-  Future remove(String key) => Future.value();
+  Future<void> remove(String key) => Future.value();
 
   @override
   Future<void> shutdown() => Future.value();

--- a/test/flutter_analysis_server_test.dart
+++ b/test/flutter_analysis_server_test.dart
@@ -298,10 +298,11 @@ class _MockCache implements ServerCache {
   Future<String> get(String key) => Future.value(null);
 
   @override
-  Future set(String key, String value, {Duration expiration}) => Future.value();
+  Future<void> set(String key, String value, {Duration expiration}) =>
+      Future.value();
 
   @override
-  Future remove(String key) => Future.value();
+  Future<void> remove(String key) => Future.value();
 
   @override
   Future<void> shutdown() => Future.value();

--- a/test/redis_cache_test.dart
+++ b/test/redis_cache_test.dart
@@ -91,7 +91,7 @@ void defineTests() {
         logMessages = [];
         await redisCache.set('expiringkey', 'expiringValue',
             expiration: Duration(milliseconds: 1));
-        await Future.delayed(Duration(milliseconds: 100));
+        await Future<void>.delayed(Duration(milliseconds: 100));
         await expectLater(await redisCache.get('expiringkey'), isNull);
         expect(logMessages, isEmpty);
       });
@@ -146,7 +146,7 @@ void defineTests() {
         try {
           // Wait for a retry message.
           while (logMessages.length < 2) {
-            await (Future.delayed(Duration(milliseconds: 50)));
+            await (Future<void>.delayed(Duration(milliseconds: 50)));
           }
           expect(
               logMessages.join('\n'),

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -42,7 +42,7 @@ bool dumpServerComms = false;
 OperationType lastExecuted;
 int lastOffset;
 
-Future main(List<String> args) async {
+Future<void> main(List<String> args) async {
   if (args.isEmpty) {
     print('''
 Usage: slow_test path_to_test_collection
@@ -115,7 +115,7 @@ Usage: slow_test path_to_test_collection
 }
 
 /// Init the tools, and warm them up
-Future setupTools(String sdkPath) async {
+Future<void> setupTools(String sdkPath) async {
   print('Executing setupTools');
   await analysisServer?.shutdown();
 
@@ -138,7 +138,9 @@ Future setupTools(String sdkPath) async {
   print('SetupTools done');
 }
 
-Future testPath(String path, analysis_server.AnalysisServerWrapper wrapper,
+Future<void> testPath(
+    String path,
+    analysis_server.AnalysisServerWrapper wrapper,
     comp.Compiler compiler) async {
   final f = io.File(path);
   var src = f.readAsStringSync();
@@ -393,10 +395,11 @@ class MockCache implements ServerCache {
   Future<String> get(String key) => Future.value(null);
 
   @override
-  Future set(String key, String value, {Duration expiration}) => Future.value();
+  Future<void> set(String key, String value, {Duration expiration}) =>
+      Future.value();
 
   @override
-  Future remove(String key) => Future.value();
+  Future<void> remove(String key) => Future.value();
 
   @override
   Future<void> shutdown() => Future.value();

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -33,7 +33,7 @@ void analyze() async {
 
 @Task()
 @Depends(buildStorageArtifacts)
-Future test() => TestRunner().testAsync();
+Future<dynamic> test() => TestRunner().testAsync();
 
 @DefaultTask()
 @Depends(analyze, test)
@@ -92,7 +92,7 @@ void validateStorageArtifacts() async {
   }
 }
 
-Future _validateExists(String url) async {
+Future<void> _validateExists(String url) async {
   log('checking $url...');
 
   final response = await http.head(url);
@@ -162,7 +162,7 @@ void buildStorageArtifacts() async {
   }
 }
 
-Future _buildStorageArtifacts(Directory dir) async {
+Future<void> _buildStorageArtifacts(Directory dir) async {
   final pubspec = createPubspec(includeFlutterWeb: true);
   joinFile(dir, ['pubspec.yaml']).writeAsStringSync(pubspec);
 


### PR DESCRIPTION
I like these changes for a few specific reasons:

* `Future` => `Future<void>` ensures with static analysis you won't try to use the result.
* `Future` => `Future<AnalysisServer>` changes any method/field access on the result from dynamic dispatch to static dispatch; safer, smaller, faster.
* `Future` => `Future<dynamic>` is not really a functional improvement; it lucks ugly. But it takes code that was already using dynamic (just secretly) and makes it explicit, so that developers are aware of dynamicism in their code.

Some changes like `{}` => `<dynamic, dynamic>{}` are pretty ugly. I hope that with generalized typedefs, some styles come out like `typedef JsonMap = Map<dynamic, dynamic>`, etc.