### PR TITLE
Updates to path stripping behavior

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -13,7 +13,10 @@ import 'package:path/path.dart' as path;
 /// "Unused import: 'package:flutter/material.dart'" -> "Unused import:
 /// 'package:flutter/material.dart'"
 String stripFilePaths(String str) {
+  // Match any URI. Also match URIs that are prefixed with dart:core or
+  // package:*
   final regex = RegExp(r'(?:dart:core?)?(?:package:?)?[a-z]*\/\S*');
+
   return str.replaceAllMapped(regex, (match) {
     final urlString = match.group(0);
     final pathComponents = path.split(urlString);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,16 +1,34 @@
 import 'package:path/path.dart' as path;
 
-String stripFilePaths(String s) {
-  return s.replaceAllMapped(RegExp(r'(?:package:?)?[a-z]*\/\S*'), (match) {
+/// Matches any path in the string and replaces the part of the path before the
+/// last separator with either dart:core, package:flutter, or removes it.
+///
+/// ## Examples:
+///
+/// "Unused import: '/path/foo.dart'" -> "Unused import: 'foo.dart'"
+///
+/// "Unused import: '/path/to/dart/lib/world.dart'" -> "Unused import:
+/// 'dart:core/world.dart'"
+///
+/// "Unused import: 'package:flutter/material.dart'" -> "Unused import:
+/// 'package:flutter/material.dart'"
+String stripFilePaths(String str) {
+  final regex = RegExp(r'(?:dart:core?)?(?:package:?)?[a-z]*\/\S*');
+  return str.replaceAllMapped(regex, (match) {
     final urlString = match.group(0);
     final pathComponents = path.split(urlString);
     final isDartPath = pathComponents.contains('lib');
     final isFlutterPath = isDartPath && pathComponents.contains('flutter');
     final isPackagePath = urlString.contains('package:');
+    final isDartCorePath = urlString.contains('dart:core');
     final basename = path.basename(urlString);
 
     if (isFlutterPath) {
       return path.join('package:flutter', basename);
+    }
+
+    if (isDartCorePath) {
+      return urlString;
     }
 
     if (isDartPath) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -26,7 +26,7 @@ String stripFilePaths(String str) {
     // matches the 'flutter' package in the SDK
     final isFlutterPath = pathComponents
         .contains('flutter');
-    
+
     final isPackagePath = urlString.contains('package:');
     final isDartCorePath = urlString.contains('dart:core');
     final basename = path.basename(urlString);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -24,8 +24,7 @@ String stripFilePaths(String str) {
         pathComponents.contains('lib') && pathComponents.contains('core');
 
     // matches the 'flutter' package in the SDK
-    final isFlutterPath = pathComponents
-        .contains('flutter');
+    final isFlutterPath = pathComponents.contains('flutter');
 
     final isPackagePath = urlString.contains('package:');
     final isDartCorePath = urlString.contains('dart:core');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -20,8 +20,13 @@ String stripFilePaths(String str) {
   return str.replaceAllMapped(regex, (match) {
     final urlString = match.group(0);
     final pathComponents = path.split(urlString);
-    final isDartPath = pathComponents.contains('lib');
-    final isFlutterPath = isDartPath && pathComponents.contains('flutter');
+    final isDartPath =
+        pathComponents.contains('lib') && pathComponents.contains('core');
+
+    // matches the 'flutter' package in the SDK
+    final isFlutterPath = pathComponents
+        .contains('flutter');
+    
     final isPackagePath = urlString.contains('package:');
     final isDartCorePath = urlString.contains('dart:core');
     final basename = path.basename(urlString);

--- a/test/utils_test.unit
+++ b/test/utils_test.unit
@@ -14,6 +14,10 @@ The argument type 'List<int> (where List is defined in dart:core/list.dart)' can
 Unused import: 'package:flutter/material.dart'.
 <<<
 Unused import: 'package:flutter/material.dart'.
+>>> Keeps dart:core paths intact
+dart:core/foo.dart
+<<<
+dart:core/foo.dart
 >>> Strips Flutter SDK paths
 The argument type 'StatelessWidget (where StatelessWidget is defined in /Users/username/path/to/dart-services/project_templates/flutter_project/main.dart)' can't be assigned to the parameter type 'StatelessWidget (where StatelessWidget is defined in /Users/username/path/to/dart-services/flutter-sdk/packages/flutter/lib/src/widgets/framework.dart)'.
 <<<

--- a/test/utils_test.unit
+++ b/test/utils_test.unit
@@ -3,7 +3,7 @@ List is defined in /var/folders/4p/y54w9nqj0_n6ryqwn7lxqz6800m6cw/T/DartAnalysis
 <<<
 List is defined in main.dart
 >>> Strips Dart SDK paths
-List is defined in /Users/ryjohn/.dvm/darts/2.10.5/lib/core/list.dart
+List is defined in /path/dart/dart/sdk/lib/core/list.dart
 <<<
 List is defined in dart:core/list.dart
 >>> Strips SDK and temporary directory paths


### PR DESCRIPTION
- Ensures that any paths with `dart:core` is kept intact, in case the analyzer decides to use these instead in the future.
- Improves check for whether or not a path is referring to the Dart SDK
- Adds documentation + comments

cc: @devoncarew @bwilkerson 