### PR TITLE
Copy Flutter analysis_options_user.yaml into flutter project dir.

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -125,6 +125,14 @@ void buildProjectTemplates() async {
   final flutterProjectDir = await flutterProjectPath.create(recursive: true);
   joinFile(flutterProjectDir, ['pubspec.yaml'])
       .writeAsStringSync(createPubspec(includeFlutterWeb: true));
+  final optionsFile = await joinFile(Directory(flutterSdkPath),
+      ['packages', 'flutter', 'analysis_options_user.yaml']);
+  if (await optionsFile.exists()) {
+    optionsFile
+        .copy(path.join(flutterProjectDir.path, 'analysis_options.yaml'));
+  } else {
+    log("Flutter user analysis options file ${optionsFile.path} doesn't exist, using default.");
+  }
   await _runFlutterPubGet(flutterProjectDir);
 }
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -119,21 +119,21 @@ void buildProjectTemplates() async {
   joinFile(dartProjectDir, ['pubspec.yaml'])
       .writeAsStringSync(createPubspec(includeFlutterWeb: false));
   await _runDartPubGet(dartProjectDir);
+  joinFile(dartProjectDir, ['analysis_options.yaml'])
+      .writeAsStringSync(createDartAnalysisOptions());
 
   final flutterProjectPath =
       Directory(path.join(templatesPath.path, 'flutter_project'));
   final flutterProjectDir = await flutterProjectPath.create(recursive: true);
   joinFile(flutterProjectDir, ['pubspec.yaml'])
       .writeAsStringSync(createPubspec(includeFlutterWeb: true));
-  final optionsFile = await joinFile(Directory(flutterSdkPath),
-      ['packages', 'flutter', 'analysis_options_user.yaml']);
-  if (await optionsFile.exists()) {
-    optionsFile
-        .copy(path.join(flutterProjectDir.path, 'analysis_options.yaml'));
-  } else {
-    log("Flutter user analysis options file ${optionsFile.path} doesn't exist, using default.");
-  }
   await _runFlutterPubGet(flutterProjectDir);
+  // TODO(gspencergoog): Convert this to use the flutter recommended lints as
+  // soon as those are finalized (the current proposal is to leave the
+  // analysis_options_user.yaml file as-is and replace it with a package, to
+  // avoid massive breakage).
+  joinFile(flutterProjectDir, ['analysis_options.yaml']).writeAsStringSync(
+      'include: package:flutter/analysis_options_user.yaml\n');
 }
 
 Future<void> _runDartPubGet(Directory dir) async {
@@ -376,4 +376,50 @@ dependencies:
   }
 
   return content;
+}
+
+String createDartAnalysisOptions() {
+  // TODO(gspencergoog): Update this to Dart "recommended" list once that is finalized.
+  return '''
+analyzer:
+  errors:
+    # Increase the severity of some hints.
+    - unused_import: warning
+
+linter:
+  rules:
+    # Ordering lints.
+    - directives_ordering
+    - sort_pub_dependencies
+
+    # All other lints.
+    - always_declare_return_types
+    - avoid_empty_else
+    - avoid_relative_lib_imports
+    - avoid_shadowing_type_parameters
+    - avoid_types_as_parameter_names
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - curly_braces_in_flow_control_structures
+    - empty_catches
+    - file_names
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - no_duplicate_case_values
+    - non_constant_identifier_names
+    - package_prefixed_library_names
+    - prefer_generic_function_type_aliases
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - prefer_typing_uninitialized_variables
+    - provide_deprecation_message
+    - unawaited_futures
+    - unnecessary_overrides
+    - unrelated_type_equality_checks
+    - valid_regexps
+    - void_checks
+''';
 }


### PR DESCRIPTION
# Description
Currently, the Flutter dartpad samples appear to be using the dart-services analysis_options.yaml file for their analysis options.  They should be using the analysis options in Flutter's `packages/flutter/analysis_options_user.yaml` file instead.  This PR adjusts grind.dart to do that.

# Related Issues

- https://github.com/flutter/flutter/issues/77425

/cc @domesticmouse 