### PR TITLE
Change how imports are parsed and evaluated.

### DIFF
--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -316,11 +316,10 @@ abstract class AnalysisServerWrapper {
       });
 
       // Calculate the imports.
-      final packageImports = <String>{};
-      for (final source in sources.values) {
-        packageImports
-            .addAll(filterSafePackagesFromImports(getAllImportsFor(source)));
-      }
+      final packageImports = {
+        for (final source in sources.values)
+          ...getAllImportsFor(source).filterSafePackages(),
+      };
 
       return proto.AnalysisResults()
         ..issues.addAll(issues)

--- a/lib/src/analysis_servers.dart
+++ b/lib/src/analysis_servers.dart
@@ -160,11 +160,13 @@ class AnalysisServersWrapper {
 
   /// Check that the set of packages referenced is valid.
   Future<void> _checkPackageReferences(String source) async {
-    final imports = getAllImportsFor(source);
+    final unsupportedImports =
+        _flutterWebManager.getUnsupportedImports(getAllImportsFor(source));
 
-    if (_flutterWebManager.hasUnsupportedImport(imports)) {
-      throw BadRequest(
-          'Unsupported input: ${_flutterWebManager.getUnsupportedImport(imports)}');
+    if (unsupportedImports.isNotEmpty) {
+      // TODO(srawlins): Do the work so that each unsupported input is its own
+      // error, with a proper SourceSpan.
+      throw BadRequest('Unsupported input(s): $unsupportedImports');
     }
   }
 }

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -38,10 +38,6 @@ class Compiler {
             maxWorkers: 1),
         _flutterWebManager = FlutterWebManager();
 
-  bool importsOkForCompile(Set<String> imports) {
-    return !_flutterWebManager.hasUnsupportedImport(imports);
-  }
-
   Future<CompilationResults> warmup({bool useHtml = false}) async {
     return compile(useHtml ? sampleCodeWeb : sampleCode);
   }
@@ -52,11 +48,12 @@ class Compiler {
     bool returnSourceMap = false,
   }) async {
     final imports = getAllImportsFor(input);
-    if (!importsOkForCompile(imports)) {
-      return CompilationResults(problems: <CompilationProblem>[
-        CompilationProblem._(
-          'unsupported import: ${_flutterWebManager.getUnsupportedImport(imports)}',
-        ),
+    final unsupportedImports =
+        _flutterWebManager.getUnsupportedImports(imports);
+    if (unsupportedImports.isNotEmpty) {
+      return CompilationResults(problems: [
+        for (var import in unsupportedImports)
+          CompilationProblem._('unsupported import: ${import.uri.stringValue}'),
       ]);
     }
 
@@ -122,11 +119,12 @@ class Compiler {
   /// Compile the given string and return the resulting [DDCCompilationResults].
   Future<DDCCompilationResults> compileDDC(String input) async {
     final imports = getAllImportsFor(input);
-    if (!importsOkForCompile(imports)) {
-      return DDCCompilationResults.failed(<CompilationProblem>[
-        CompilationProblem._(
-          'unsupported import: ${_flutterWebManager.getUnsupportedImport(imports)}',
-        ),
+    final unsupportedImports =
+        _flutterWebManager.getUnsupportedImports(imports);
+    if (unsupportedImports.isNotEmpty) {
+      return DDCCompilationResults.failed([
+        for (var import in unsupportedImports)
+          CompilationProblem._('unsupported import: ${import.uri.stringValue}'),
       ]);
     }
 

--- a/lib/src/pub.dart
+++ b/lib/src/pub.dart
@@ -4,78 +4,23 @@
 
 // ignore_for_file: implementation_imports
 
-import 'package:analyzer/dart/ast/token.dart';
-import 'package:analyzer/error/listener.dart';
-import 'package:analyzer/src/dart/scanner/reader.dart';
-import 'package:analyzer/src/dart/scanner/scanner.dart';
-import 'package:analyzer/src/string_source.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 
-import 'common.dart';
+List<ImportDirective> getAllImportsFor(String dartSource) {
+  if (dartSource == null) return [];
 
-Set<String> getAllImportsFor(String dartSource) {
-  if (dartSource == null) return <String>{};
+  final unit = parseString(content: dartSource, throwIfDiagnostics: false).unit;
+  return unit.directives.whereType<ImportDirective>().toList();
+}
 
-  final scanner = Scanner(
-    StringSource(dartSource, kMainDart),
-    CharSequenceReader(dartSource),
-    AnalysisErrorListener.NULL_LISTENER,
-  );
-  var token = scanner.tokenize();
-
-  final imports = <String>{};
-
-  while (token.type != TokenType.EOF) {
-    if (_isLibrary(token)) {
-      token = _consumeSemi(token);
-    } else if (_isImport(token)) {
-      token = token.next;
-
-      if (token.type == TokenType.STRING) {
-        imports.add(stripMatchingQuotes(token.lexeme));
-      }
-
-      token = _consumeSemi(token);
-    } else {
-      break;
-    }
+extension ImportIterableExtensions on Iterable<ImportDirective> {
+  /// Returns the names of packages that are referenced in this collection.
+  /// These package names are sanitized defensively.
+  Iterable<String> filterSafePackages() {
+    return where((import) => !import.uri.stringValue.startsWith('package:../'))
+        .map((import) => Uri.parse(import.uri.stringValue))
+        .where((uri) => uri.scheme == 'package' && uri.pathSegments.isNotEmpty)
+        .map((uri) => uri.pathSegments.first);
   }
-
-  return imports;
-}
-
-/// Return the list of packages that are imported from the given imports. These
-/// packages are sanitized defensively.
-Set<String> filterSafePackagesFromImports(Set<String> allImports) {
-  return Set<String>.from(allImports.where((String import) {
-    return import.startsWith('package:');
-  }).map((String import) {
-    return import.substring(8);
-  }).map((String import) {
-    final index = import.indexOf('/');
-    return index == -1 ? import : import.substring(0, index);
-  }).map((String import) {
-    return import.replaceAll('..', '');
-  }).where((String import) {
-    return import.isNotEmpty;
-  }));
-}
-
-bool _isLibrary(Token token) {
-  return token.isKeyword && token.lexeme == 'library';
-}
-
-bool _isImport(Token token) {
-  return token.isKeyword && token.lexeme == 'import';
-}
-
-Token _consumeSemi(Token token) {
-  while (token.type != TokenType.SEMICOLON) {
-    if (token.type == TokenType.EOF) return token;
-    token = token.next;
-  }
-
-  // Skip past the semi-colon.
-  token = token.next;
-
-  return token;
 }

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -169,8 +169,9 @@ import 'foo.dart';
 void main() { missingMethod ('foo'); }
 ''';
         final result = await compiler.compile(code);
-        expect(result.problems.first.message,
-            equals('unsupported import: foo.dart'));
+        expect(result.problems, hasLength(1));
+        expect(result.problems.single.message,
+            equals('unsupported imports: foo.dart'));
       });
 
       test('bad import - http', () async {
@@ -179,8 +180,22 @@ import 'http://example.com';
 void main() { missingMethod ('foo'); }
 ''';
         final result = await compiler.compile(code);
-        expect(result.problems.first.message,
-            equals('unsupported import: http://example.com'));
+        expect(result.problems, hasLength(1));
+        expect(result.problems.single.message,
+            equals('unsupported imports: http://example.com'));
+      });
+
+      test('multiple bad imports', () async {
+        const code = '''
+import 'package:foo';
+import 'package:bar';
+''';
+        final result = await compiler.compile(code);
+        expect(result.problems, hasLength(2));
+        expect(result.problems[0].message,
+            equals('unsupported imports: package:foo'));
+        expect(result.problems[1].message,
+            equals('unsupported imports: package:bar'));
       });
 
       test('disallow compiler warnings', () async {

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -171,7 +171,7 @@ void main() { missingMethod ('foo'); }
         final result = await compiler.compile(code);
         expect(result.problems, hasLength(1));
         expect(result.problems.single.message,
-            equals('unsupported imports: foo.dart'));
+            equals('unsupported import: foo.dart'));
       });
 
       test('bad import - http', () async {
@@ -182,7 +182,7 @@ void main() { missingMethod ('foo'); }
         final result = await compiler.compile(code);
         expect(result.problems, hasLength(1));
         expect(result.problems.single.message,
-            equals('unsupported imports: http://example.com'));
+            equals('unsupported import: http://example.com'));
       });
 
       test('multiple bad imports', () async {
@@ -193,9 +193,9 @@ import 'package:bar';
         final result = await compiler.compile(code);
         expect(result.problems, hasLength(2));
         expect(result.problems[0].message,
-            equals('unsupported imports: package:foo'));
+            equals('unsupported import: package:foo'));
         expect(result.problems[1].message,
-            equals('unsupported imports: package:bar'));
+            equals('unsupported import: package:bar'));
       });
 
       test('disallow compiler warnings', () async {

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -19,7 +19,9 @@ void defineTests() {
     });
 
     test('bad source', () {
-      expect(getAllImportsFor('foo bar;\n baz\nimport mybad;\n'), isEmpty);
+      final imports = getAllImportsFor('foo bar;\n baz\nimport mybad;\n');
+      expect(imports, hasLength(1));
+      expect(imports.single.uri.stringValue, equals(''));
     });
 
     test('one', () {
@@ -29,7 +31,7 @@ import 'dart:math';
 import 'package:foo/foo.dart';
 void main() { }
 ''';
-      expect(getAllImportsFor(source),
+      expect(getAllImportsFor(source).map((import) => import.uri.stringValue),
           unorderedEquals(['dart:math', 'package:foo/foo.dart']));
     });
 
@@ -42,7 +44,7 @@ import 'package:bar/bar.dart';
 void main() { }
 ''';
       expect(
-          getAllImportsFor(source),
+          getAllImportsFor(source).map((import) => import.uri.stringValue),
           unorderedEquals(
               ['dart:math', 'package:foo/foo.dart', 'package:bar/bar.dart']));
     });
@@ -57,7 +59,7 @@ import 'mybazfile.dart';
 void main() { }
 ''';
       expect(
-          getAllImportsFor(source),
+          getAllImportsFor(source).map((import) => import.uri.stringValue),
           unorderedEquals([
             'dart:math',
             'package:foo/foo.dart',
@@ -73,7 +75,7 @@ void main() { }
       const source = '''import 'package:';
 void main() { }
 ''';
-      expect(filterSafePackagesFromImports(getAllImportsFor(source)), isEmpty);
+      expect(getAllImportsFor(source).filterSafePackages(), isEmpty);
     });
 
     test('simple', () {
@@ -82,7 +84,7 @@ import 'package:foo/foo.dart';
 import 'package:bar/bar.dart';
 void main() { }
 ''';
-      expect(filterSafePackagesFromImports(getAllImportsFor(source)),
+      expect(getAllImportsFor(source).filterSafePackages(),
           unorderedEquals(['foo', 'bar']));
     });
 
@@ -94,9 +96,10 @@ import 'package:../foo/foo.dart';
 void main() { }
 ''';
       final imports = getAllImportsFor(source);
-      expect(
-          imports, unorderedMatches(['dart:math', 'package:../foo/foo.dart']));
-      expect(filterSafePackagesFromImports(imports), isEmpty);
+      expect(imports, hasLength(2));
+      expect(imports[0].uri.stringValue, equals('dart:math'));
+      expect(imports[1].uri.stringValue, equals('package:../foo/foo.dart'));
+      expect(imports.filterSafePackages(), isEmpty);
     });
 
     test('negative dart import', () {
@@ -104,8 +107,9 @@ void main() { }
 import 'dart:../bar.dart';
 ''';
       final imports = getAllImportsFor(source);
-      expect(imports, unorderedMatches(['dart:../bar.dart']));
-      expect(filterSafePackagesFromImports(imports), isEmpty);
+      expect(imports, hasLength(1));
+      expect(imports.single.uri.stringValue, equals('dart:../bar.dart'));
+      expect(imports.filterSafePackages(), isEmpty);
     });
 
     test('negative path import', () {
@@ -113,8 +117,9 @@ import 'dart:../bar.dart';
 import '../foo.dart';
 ''';
       final imports = getAllImportsFor(source);
-      expect(imports, unorderedMatches(['../foo.dart']));
-      expect(filterSafePackagesFromImports(imports), isEmpty);
+      expect(imports, hasLength(1));
+      expect(imports.single.uri.stringValue, equals('../foo.dart'));
+      expect(imports.filterSafePackages(), isEmpty);
     });
   });
 }


### PR DESCRIPTION
This mostly simplifies how import directives are parsed, and how the URIs of
the imports are parsed and evaluated.

Working with ImportDirectives allows us to reference the SourceSpan (line
and offsets) of bad imports.

This allows multiple compiler errors to be returned if there are multiple
unallowed import directives. It paves the way a bit for multiple analysis
errors to be returned as well.

Work towards https://github.com/dart-lang/dart-pad/issues/1826.