### PR TITLE
Tweak unsupported imports message

### DIFF
--- a/lib/src/analysis_servers.dart
+++ b/lib/src/analysis_servers.dart
@@ -166,7 +166,9 @@ class AnalysisServersWrapper {
     if (unsupportedImports.isNotEmpty) {
       // TODO(srawlins): Do the work so that each unsupported input is its own
       // error, with a proper SourceSpan.
-      throw BadRequest('Unsupported input(s): $unsupportedImports');
+      final unsupportedUris =
+          unsupportedImports.map((import) => import.uri.stringValue);
+      throw BadRequest('Unsupported import(s): $unsupportedUris');
     }
   }
 }


### PR DESCRIPTION
Right now the message reads something like:

> line 1 • Unsupported input(s): [import 'package:firebase/firebase.dart';, import 'package:firebase/firestore.dart' as fs;]

which hurts my eyes and my brain. The fix changes this to:

> line 1 • Unsupported import(s): (package:firebase/firebase.dart, package:firebase/firestore.dart)