### PR TITLE
Bump nullSafe version to 2.13 to allow for non-function typedefs

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -416,7 +416,7 @@ String createPubspec(
   var content = '''
 name: $_samplePackageName
 environment:
-  sdk: '>=${nullSafety ? '2.12.0' : '2.10.0'} <3.0.0'
+  sdk: '>=${nullSafety ? '2.13.0' : '2.10.0'} <3.0.0'
 dependencies:
 ''';
 


### PR DESCRIPTION
Fixes #1901

Tested locally; seems to work fine.