### PR TITLE
Revert "Use the official Dart image (#715)"

### DIFF
--- a/cloud_run.Dockerfile
+++ b/cloud_run.Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.13.1-sdk
+FROM google/dart:2.13.0
 
 # We install unzip and remove the apt-index again to keep the
 # docker image diff small.

--- a/cloud_run_null_safety.Dockerfile
+++ b/cloud_run_null_safety.Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.13.1-sdk
+FROM google/dart:2.13.0
 
 # We install unzip and remove the apt-index again to keep the
 # docker image diff small.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -52,8 +52,8 @@ Future<void> serveNullSafety() async {
       arguments: ['bin/server_dev.dart', '--port', '8084', '--null-safety']);
 }
 
-const _dartImageName = 'dart';
-final _dockerVersionMatcher = RegExp('^FROM $_dartImageName:(.*)-sdk\$');
+const _dartImageName = 'google/dart';
+final _dockerVersionMatcher = RegExp('^FROM $_dartImageName:(.*)\$');
 const _dockerFileNames = [
   'cloud_run.Dockerfile',
   'cloud_run_null_safety.Dockerfile'
@@ -66,7 +66,7 @@ void updateDockerVersion() {
     final dockerFile = File(_dockerFileName);
     final dockerImageLines = dockerFile.readAsLinesSync().map((String s) {
       if (s.contains(_dockerVersionMatcher)) {
-        return 'FROM $_dartImageName:$platformVersion-sdk';
+        return 'FROM $_dartImageName:$platformVersion';
       }
       return s;
     }).toList();


### PR DESCRIPTION
This reverts commit bd3b40cc12dad9d7dfcd9d8cbc342c19714cdeb6.

This change broke the Cloud Builders:

```
starting build "9a9a886a-6bdf-4559-913e-2879269c8176"

FETCHSOURCE
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
Initialized empty Git repository in /workspace/.git/
From https://github.com/dart-lang/dart-services
 * branch            068ebc7db03222ece4c596c74c2dac19e9f604cd -> FETCH_HEAD
HEAD is now at 068ebc7 Pub upgrade major versions (#716)
BUILD
Starting Step #0 - "Build"
Step #0 - "Build": Already have image (with digest): gcr.io/cloud-builders/docker
Step #0 - "Build": Sending build context to Docker daemon  798.2kB

Step #0 - "Build": Step 1/17 : FROM dart:2.13.1-sdk
Step #0 - "Build": 2.13.1-sdk: Pulling from library/dart
Step #0 - "Build": 69692152171a: Pulling fs layer
Step #0 - "Build": 4ef6b6cb7d8e: Pulling fs layer
Step #0 - "Build": bb4bafd8baa9: Pulling fs layer
Step #0 - "Build": 61b8754f3725: Pulling fs layer
Step #0 - "Build": 61b8754f3725: Waiting
Step #0 - "Build": bb4bafd8baa9: Verifying Checksum
Step #0 - "Build": bb4bafd8baa9: Download complete
Step #0 - "Build": 69692152171a: Verifying Checksum
Step #0 - "Build": 69692152171a: Download complete
Step #0 - "Build": 4ef6b6cb7d8e: Verifying Checksum
Step #0 - "Build": 4ef6b6cb7d8e: Download complete
Step #0 - "Build": 69692152171a: Pull complete
Step #0 - "Build": 4ef6b6cb7d8e: Pull complete
Step #0 - "Build": bb4bafd8baa9: Pull complete
Step #0 - "Build": 61b8754f3725: Verifying Checksum
Step #0 - "Build": 61b8754f3725: Download complete
Step #0 - "Build": 61b8754f3725: Pull complete
Step #0 - "Build": Digest: sha256:76d0bf1a79e33bd6e104275aba3d8a1e8479705323ec0e8b00ced40616024c7b
Step #0 - "Build": Status: Downloaded newer image for dart:2.13.1-sdk
Step #0 - "Build":  ---> 1d4d5235c6c4
Step #0 - "Build": Step 2/17 : RUN apt-get update &&   apt-get install -y unzip &&   rm -rf /var/lib/apt/lists/*
Step #0 - "Build":  ---> Running in ba042de81725
Step #0 - "Build": Get:1 http://deb.debian.org/debian buster InRelease [121 kB]
Step #0 - "Build": Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Step #0 - "Build": Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Step #0 - "Build": Get:4 http://security.debian.org/debian-security buster/updates/main amd64 Packages [290 kB]
Step #0 - "Build": Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7907 kB]
Step #0 - "Build": Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [10.9 kB]
Step #0 - "Build": Fetched 8447 kB in 2s (4593 kB/s)
Step #0 - "Build": Reading package lists...
Step #0 - "Build": Reading package lists...
Step #0 - "Build": Building dependency tree...
Step #0 - "Build": Reading state information...
Step #0 - "Build": unzip is already the newest version (6.0-23+deb10u2).
Step #0 - "Build": 0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Step #0 - "Build": Removing intermediate container ba042de81725
Step #0 - "Build":  ---> 4e6c73ed8724
Step #0 - "Build": Step 3/17 : WORKDIR /app
Step #0 - "Build":  ---> Running in 6a1c8400cd97
Step #0 - "Build": Removing intermediate container 6a1c8400cd97
Step #0 - "Build":  ---> 1ba0430bba93
Step #0 - "Build": Step 4/17 : RUN groupadd --system dart &&   useradd --no-log-init --system --home /home/dart --create-home -g dart dart
Step #0 - "Build":  ---> Running in 3cd2336a07b1
Step #0 - "Build": Removing intermediate container 3cd2336a07b1
Step #0 - "Build":  ---> 7746b2de4410
Step #0 - "Build": Step 5/17 : RUN chown dart:dart /app
Step #0 - "Build":  ---> Running in 307c412bd9fb
Step #0 - "Build": Removing intermediate container 307c412bd9fb
Step #0 - "Build":  ---> 62c820b772b2
Step #0 - "Build": Step 6/17 : USER dart
Step #0 - "Build":  ---> Running in 691c70b06367
Step #0 - "Build": Removing intermediate container 691c70b06367
Step #0 - "Build":  ---> d9b7b572d616
Step #0 - "Build": Step 7/17 : COPY --chown=dart:dart tool/dart_cloud_run.sh /dart_runtime/
Step #0 - "Build":  ---> c4883096e716
Step #0 - "Build": Step 8/17 : RUN chmod a+x /dart_runtime/dart_cloud_run.sh
Step #0 - "Build":  ---> Running in 1a4b6dfb5321
Step #0 - "Build": Removing intermediate container 1a4b6dfb5321
Step #0 - "Build":  ---> 7730e1427e62
Step #0 - "Build": Step 9/17 : COPY --chown=dart:dart pubspec.* /app/
Step #0 - "Build":  ---> 4a30145abb66
Step #0 - "Build": Step 10/17 : RUN pub get
Step #0 - "Build":  ---> Running in 95409ed2e09e
Step #0 - "Build": [91m/bin/sh: 1: pub: Permission denied
Step #0 - "Build": The command '/bin/sh -c pub get' returned a non-zero code: 127
Finished Step #0 - "Build"
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 127
Step #0 - "Build": [0m
```