### PR TITLE
Allow a few package imports in non-Flutter scripts

### DIFF
--- a/test/flutter_web_test.dart
+++ b/test/flutter_web_test.dart
@@ -36,19 +36,39 @@ void defineTests() {
         expect(project.usesFlutterWeb({packageFlutterImport}), isTrue);
       });
 
-      test('getUnsupportedImport', () {
+      test('getUnsupportedImport allows dart:html', () {
         expect(
             project.getUnsupportedImports([_FakeImportDirective('dart:html')]),
             isEmpty);
+      });
+
+      test('getUnsupportedImport allows dart:ui', () {
         expect(project.getUnsupportedImports([dartUiImport]), isEmpty);
+      });
+
+      test('getUnsupportedImport allows package:flutter', () {
         expect(project.getUnsupportedImports([packageFlutterImport]), isEmpty);
+      });
+
+      test('getUnsupportedImport allows package:path', () {
         final packagePathImport = _FakeImportDirective('package:path');
-        expect(project.getUnsupportedImports([packagePathImport]),
-            contains(packagePathImport));
+        expect(project.getUnsupportedImports([packagePathImport]), isEmpty);
+      });
+
+      test('getUnsupportedImport does now allow package:unsupported', () {
+        final usupportedPackageImport =
+            _FakeImportDirective('package:unsupported');
+        expect(project.getUnsupportedImports([usupportedPackageImport]),
+            contains(usupportedPackageImport));
+      });
+
+      test('getUnsupportedImport does now allow local imports', () {
         final localFooImport = _FakeImportDirective('foo.dart');
         expect(project.getUnsupportedImports([localFooImport]),
             contains(localFooImport));
-        // dart:io is an unsupported package.
+      });
+
+      test('getUnsupportedImport does not allow VM-only imports', () {
         final dartIoImport = _FakeImportDirective('dart:io');
         expect(project.getUnsupportedImports([dartIoImport]),
             contains(dartIoImport));


### PR DESCRIPTION
If a user script does not appear to be a Flutter script, our current pubspec templates do not allow _any_ package imports. This changes that to add a few specific packages.

This also tightens up the notions of allowed packages; previously we were relying on string implementations, which can lead to bugs (e.g. if a certain Sam forgets to allow flutter_test in writing `package:flutter/`).

Here's the list:

* characters
* collection
* js
* meta
* path
* pedantic
* vector_math