### PR TITLE
Elide Dart beta SDK from CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -18,9 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Disabling Dart dev SDK due to https://github.com/google/dart-neats/issues/132
+        # Disabling Dart beta and dev SDK due to https://github.com/google/dart-neats/issues/132
         # sdk: [stable, beta, dev]
-        sdk: [stable, beta]
+        sdk: [stable]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0


### PR DESCRIPTION
Continuing issues with https://github.com/google/dart-neats/issues/132