### PR TITLE
Adjust how the Sdk class is constructed

### DIFF
--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -20,7 +20,7 @@ const nullSafe = false;
 void main(List<String> args) async {
   final json = args.contains('--json');
   final harness = BenchmarkHarness(asJson: json);
-  final compiler = Compiler(Sdk(), nullSafe);
+  final compiler = Compiler(Sdk.create(), nullSafe);
 
   Logger.root.level = Level.WARNING;
   Logger.root.onRecord.listen((LogRecord record) {

--- a/lib/src/common_server_impl.dart
+++ b/lib/src/common_server_impl.dart
@@ -57,7 +57,7 @@ class CommonServerImpl {
   Future<void> init() async {
     log.info('Beginning CommonServer init().');
     _analysisServers = AnalysisServersWrapper(_nullSafety);
-    _compiler = Compiler(Sdk(), _nullSafety);
+    _compiler = Compiler(Sdk.create(), _nullSafety);
 
     await _compiler.warmup();
     await _analysisServers.warmup();
@@ -151,7 +151,7 @@ class CommonServerImpl {
   }
 
   Future<proto.VersionResponse> version(proto.VersionRequest _) {
-    final sdk = Sdk();
+    final sdk = Sdk.create();
     final packageVersions = getPackageVersions(nullSafe: _nullSafety);
 
     return Future.value(

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -10,18 +10,26 @@ import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
 class Sdk {
-  static late final Sdk _instance = Sdk._();
-  // TODO: eliminate this factory constructor
-  factory Sdk() => _instance;
+  static late Sdk? _instance;
 
   /// The current version of the SDK, including any `-dev` suffix.
   final String versionFull;
 
   final String flutterVersion;
 
-  Sdk._()
-      : versionFull = _readVersionFile(sdkPath),
-        flutterVersion = _readVersionFile(flutterSdkPath);
+  /// The current version of the SDK, not including any `-dev` suffix.
+  final String version;
+
+  factory Sdk.create() {
+    return _instance ??= Sdk._(
+        versionFull: _readVersionFile(sdkPath),
+        flutterVersion: _readVersionFile(flutterSdkPath));
+  }
+
+  Sdk._({required this.versionFull, required this.flutterVersion})
+      : version = versionFull.contains('-')
+            ? versionFull.substring(0, versionFull.indexOf('-'))
+            : versionFull;
 
   static String _readVersionFile(String filePath) =>
       (File(path.join(filePath, 'version')).readAsStringSync()).trim();
@@ -35,13 +43,6 @@ class Sdk {
 
   /// Get the path to the Flutter binaries.
   static String get flutterBinPath => path.join(flutterSdkPath, 'bin');
-
-  /// Report the current version of the SDK.
-  String get version {
-    var ver = versionFull;
-    if (ver.contains('-')) ver = ver.substring(0, ver.indexOf('-'));
-    return ver;
-  }
 }
 
 class DownloadingSdkManager {
@@ -59,7 +60,7 @@ class DownloadingSdkManager {
   /// `flutter-sdk-version.yaml` file.
   ///
   /// Note that this is an expensive operation.
-  Future<Sdk> createFromConfigFile() async {
+  Future<void> createFromConfigFile() async {
     final sdkConfig = getSdkConfigInfo();
 
     // flutter_sdk:
@@ -81,7 +82,7 @@ class DownloadingSdkManager {
       return createUsingFlutterVersion(version: config['version'] as String);
     } else {
       // Clone the repo if necessary but don't do any other setup.
-      return (await _cloneSdkIfNecessary()).asSdk();
+      await _cloneSdkIfNecessary();
     }
   }
 
@@ -89,7 +90,7 @@ class DownloadingSdkManager {
   /// channel.
   ///
   /// Note that this is an expensive operation.
-  Future<Sdk> createUsingFlutterChannel({
+  Future<void> createUsingFlutterChannel({
     required String channel,
   }) async {
     final sdk = await _cloneSdkIfNecessary();
@@ -106,15 +107,13 @@ class DownloadingSdkManager {
 
     // git pull
     await sdk.pull();
-
-    return sdk.asSdk();
   }
 
   /// Create a Flutter SDK in `flutter-sdk/` that tracks a specific Flutter
   /// version.
   ///
   /// Note that this is an expensive operation.
-  Future<Sdk> createUsingFlutterVersion({
+  Future<void> createUsingFlutterVersion({
     required String version,
   }) async {
     final sdk = await _cloneSdkIfNecessary();
@@ -128,8 +127,6 @@ class DownloadingSdkManager {
 
     // Force downloading of Dart SDK before constructing the Sdk singleton.
     await sdk.init();
-
-    return sdk.asSdk();
   }
 
   Future<_DownloadedFlutterSdk> _cloneSdkIfNecessary() async {
@@ -159,11 +156,9 @@ class _DownloadedFlutterSdk {
   _DownloadedFlutterSdk(this.flutterSdkPath);
 
   Future<void> init() async {
-    // flutter --version takes ~28s
+    // `flutter --version` takes ~28s.
     await _execLog('bin/flutter', ['--version'], flutterSdkPath);
   }
-
-  Sdk asSdk() => Sdk();
 
   String get sdkPath => path.join(flutterSdkPath, 'bin/cache/dart-sdk');
 

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
 class Sdk {
-  static late Sdk? _instance;
+  static Sdk? _instance;
 
   /// The current version of the SDK, including any `-dev` suffix.
   final String versionFull;

--- a/lib/src/server_cache.dart
+++ b/lib/src/server_cache.dart
@@ -143,7 +143,7 @@ class RedisCache implements ServerCache {
   /// We don't use the existing key directly so that different AppEngine
   /// versions using the same redis cache do not have collisions.
   String _genKey(String key) {
-    final sdk = Sdk();
+    final sdk = Sdk.create();
     // the `rc` here is a differentiator to keep the `resp_client` documents
     // separate from the `dartis` documents.
     return 'server:rc:$serverVersion:dart:${sdk.versionFull}:flutter:${sdk.flutterVersion}+$key';

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -17,7 +17,7 @@ void defineTests() {
   for (final nullSafety in [false, true]) {
     group('Null ${nullSafety ? 'Safe' : 'Unsafe'} Compiler', () {
       setUpAll(() async {
-        compiler = Compiler(Sdk(), nullSafety);
+        compiler = Compiler(Sdk.create(), nullSafety);
         await compiler.warmup();
       });
 

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -133,7 +133,7 @@ Future<void> setupTools(String sdkPath) async {
   await analysisServer!.warmup();
 
   print('Warming up compiler');
-  compiler = comp.Compiler(Sdk(), false);
+  compiler = comp.Compiler(Sdk.create(), false);
   await compiler.warmup();
   print('SetupTools done');
 }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -86,7 +86,7 @@ final List<String> compilationArtifacts = [
     'google storage')
 @Depends(sdkInit)
 void validateStorageArtifacts() async {
-  final version = Sdk().versionFull;
+  final version = Sdk.create().versionFull;
 
   const nullUnsafeUrlBase =
       'https://storage.googleapis.com/compilation_artifacts/';
@@ -296,7 +296,7 @@ Future<String> _buildStorageArtifacts(Directory dir, bool nullSafety) async {
   copy(joinFile(dir, ['flutter_web.dill']), artifactsDir);
 
   // Emit some good google storage upload instructions.
-  final version = Sdk().versionFull;
+  final version = Sdk.create().versionFull;
   return ('  gsutil -h "Cache-Control: public, max-age=604800, immutable" cp -z js ${artifactsDir.path}/*.js'
       ' gs://${nullSafety ? 'nnbd_artifacts' : 'compilation_artifacts'}/$version/');
 }


### PR DESCRIPTION
At first I wanted to use the laziness of `late final`, but I saw how the constructor reads files that must get set up first, and that felt fragile to me. So I kept the public constructor, but renamed it.

I also made the `version` getter a field.

I also made the various `create` methods return `Future<void>`. Their result is never used. The Sdk, if required, will be created later, and does not need to be created in these methods.

Fixes #1940