### PR TITLE
Bump 'null safety'-enabled language version to 2.14

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -428,7 +428,7 @@ String createPubspec({
   var content = '''
 name: $_samplePackageName
 environment:
-  sdk: '>=${nullSafety ? '2.13.0' : '2.10.0'} <3.0.0'
+  sdk: '>=${nullSafety ? '2.14.0' : '2.10.0'} <3.0.0'
 dependencies:
 ''';
 


### PR DESCRIPTION
This just enables the little features for 2.14, like `>>>`.

CC @RedBrogdon 