### PR TITLE
Bump analyzer dependency to 2.5.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 
 dependencies:
   analysis_server_lib: ^0.2.0
-  analyzer: ^2.0.0
+  analyzer: ^2.5.0
   args: ^2.0.0
   bazel_worker: ^1.0.0
   crypto: ^3.0.1


### PR DESCRIPTION
I'm not seeing flakes (as much?) locally, and my pubspec.lock is using analyzer 2.5.0, so I figure maybe we should bump it; perhaps past a bug.