### PR TITLE
Lint on dynamic calls; remove proto analysis exception

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,12 +10,11 @@ analyzer:
     - doc/generated/**
     - flutter-sdk/**
     - project_templates/**
-    # TODO: This seems to be hiding ~2 dozen legitimate analysis issues. https://github.com/dart-lang/dart-pad/issues/1712
-    - lib/src/protos/**
 
 linter:
   rules:
     - always_declare_return_types
+    - avoid_dynamic_calls
     - directives_ordering
     - prefer_final_fields
     - prefer_final_in_for_each


### PR DESCRIPTION
This just removes an exception for an issues I saw. Fixes https://github.com/dart-lang/dart-pad/issues/1712

Also lint on [avoid_dynamic_calls](https://dart-lang.github.io/linter/lints/avoid_dynamic_calls.html).