### PR TITLE
Change how compilers are invoked to prepare for upcoming deprecation.

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -24,23 +24,20 @@ Logger _logger = Logger('compiler');
 class Compiler {
   final Sdk _sdk;
   final String _dartPath;
-  final String _dartdevcPath;
   final BazelWorkerDriver _ddcDriver;
   final bool _nullSafety;
   final ProjectTemplates _projectTemplates;
 
   Compiler(Sdk sdk, bool nullSafety)
-      : this._(
-            sdk,
-            nullSafety,
-            path.join(Sdk.sdkPath, 'bin', 'dart'),
-            path.join(
-                Sdk.sdkPath, 'bin', 'snapshots', 'dartdevc.dart.snapshot'));
+      : this._(sdk, nullSafety, path.join(Sdk.sdkPath, 'bin', 'dart'));
 
-  Compiler._(this._sdk, this._nullSafety, this._dartPath, this._dartdevcPath)
+  Compiler._(this._sdk, this._nullSafety, this._dartPath)
       : _ddcDriver = BazelWorkerDriver(
-            () => Process.start(
-                _dartPath, [_dartdevcPath, '--persistent_worker']),
+            () => Process.start(_dartPath, [
+                  path.join(Sdk.sdkPath, 'bin', 'snapshots',
+                      'dartdevc.dart.snapshot'),
+                  '--persistent_worker'
+                ]),
             maxWorkers: 1),
         _projectTemplates = _nullSafety
             ? ProjectTemplates.nullSafe


### PR DESCRIPTION
Change how compilers are invoked to prepare for upcoming deprecation of the dart2js and dartdevc scripts.

These scripts will be deprecated (possibly in 2.15 or later) and then removed in a future version of the Dart SDK (at least post 2.16). The `dartdevc` script will be removed, since it was never meant for end-users to invoke it, however the tool will continue to be available directly from the snapshot for dartpad and flutter tools. The `dart2js` script will be replaced by the "dart compile js" command (which is already available).