### PR TITLE
Use a local pub cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ dump.rdb
 # compilation artifacts
 artifacts/
 project_templates/
+flutter-sdks/
+local_pub_cache/
 
 # local configuration
 config.properties
@@ -27,5 +29,3 @@ config.properties
 # Editor configuration
 .vscode/
 
-# A Flutter SDK checkout
-flutter-sdks/

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,6 +13,7 @@ analyzer:
     # TODO(https://github.com/dart-lang/dart-pad/issues/1712): This seems to be
     # hiding ~2 dozen legitimate analysis issues.
     - lib/src/protos/**
+    - local_pub_cache/**
 
 linter:
   rules:


### PR DESCRIPTION
This puts all dependencies in a fix location in the local directory, and is necessary if we want to patch a dependency. We want to patch some firebase packages so that they work without JS Firebase config.

Work towards: https://github.com/dart-lang/dart-pad/issues/2068

The PUB_CACHE variable only needs to be used for `pub get` and `flutter packages get`, because after those run, the `.dart_tool/package_config.json` file has all absolute paths set, and no further tasks need to know about the custom PUB_CACHE.