### PR TITLE
Test project template creation

### DIFF
--- a/lib/src/project_creator.dart
+++ b/lib/src/project_creator.dart
@@ -1,0 +1,217 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert' show jsonDecode;
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'project.dart';
+import 'sdk.dart';
+import 'utils.dart';
+
+typedef LogFunction = void Function(String);
+
+class ProjectCreator {
+  final String _dartSdkPath;
+
+  final String _flutterToolPath;
+
+  final String _templatesPath;
+
+  final bool _isNullSafe;
+
+  final File _dependenciesFile;
+
+  final LogFunction _log;
+
+  ProjectCreator(
+    Sdk sdk,
+    this._templatesPath, {
+    required bool isNullSafe,
+    required File dependenciesFile,
+    required LogFunction log,
+  })  : _dartSdkPath = sdk.dartSdkPath,
+        _flutterToolPath = sdk.flutterToolPath,
+        _isNullSafe = isNullSafe,
+        _dependenciesFile = dependenciesFile,
+        _log = log;
+
+  /// Builds a basic Dart project template directory, complete with `pubspec.yaml`
+  /// and `analysis_options.yaml`.
+  Future<void> buildDartProjectTemplate() async {
+    final projectPath = path.join(_templatesPath,
+        _isNullSafe ? 'null-safe' : 'null-unsafe', 'dart_project');
+    final projectDirectory = Directory(projectPath);
+    await projectDirectory.create(recursive: true);
+    final dependencies = _dependencyVersions(supportedBasicDartPackages);
+    File(path.join(projectPath, 'pubspec.yaml'))
+        .writeAsStringSync(createPubspec(
+      includeFlutterWeb: false,
+      nullSafety: _isNullSafe,
+      dependencies: dependencies,
+    ));
+    await _runDartPubGet(projectDirectory);
+    File(path.join(projectPath, 'analysis_options.yaml')).writeAsStringSync('''
+include: package:lints/recommended.yaml
+linter:
+  rules:
+    avoid_print: false
+''');
+  }
+
+  /// Builds a Flutter project template directory, complete with `pubspec.yaml`,
+  /// `analysis_options.yaml`, and `web/index.html`.
+  ///
+  /// Depending on [includeFirebase], Firebase packages are included in
+  /// `pubspec.yaml` which affects how `flutter packages get` will register
+  /// plugins.
+  Future<void> buildFlutterProjectTemplate({
+    required FirebaseStyle firebaseStyle,
+  }) async {
+    final projectDirName = firebaseStyle == FirebaseStyle.none
+        ? 'flutter_project'
+        : firebaseStyle == FirebaseStyle.deprecated
+            ? 'firebase_deprecated_project'
+            : 'firebase_project';
+    final projectPath = path.join(
+      _templatesPath,
+      _isNullSafe ? 'null-safe' : 'null-unsafe',
+      projectDirName,
+    );
+    final projectDir = await Directory(projectPath).create(recursive: true);
+    await Directory(path.join(projectPath, 'lib')).create();
+    await Directory(path.join(projectPath, 'web')).create();
+    await File(path.join(projectPath, 'web', 'index.html')).create();
+    var packages = {
+      ...supportedBasicDartPackages,
+      ...supportedFlutterPackages,
+      if (firebaseStyle != FirebaseStyle.none) ...coreFirebasePackages,
+      if (firebaseStyle == FirebaseStyle.deprecated)
+        ...deprecatedFirebasePackages,
+      if (firebaseStyle == FirebaseStyle.flutterFire)
+        ...registerableFirebasePackages,
+    };
+    final dependencies = _dependencyVersions(packages);
+    File(path.join(projectPath, 'pubspec.yaml'))
+        .writeAsStringSync(createPubspec(
+      includeFlutterWeb: true,
+      nullSafety: _isNullSafe,
+      dependencies: dependencies,
+    ));
+    await runFlutterPackagesGet(_flutterToolPath, projectPath, log: _log);
+    if (firebaseStyle != FirebaseStyle.none) {
+      // `flutter packages get` has been run with a _subset_ of all supported
+      // Firebase packages, the ones that don't require a Firebase app to be
+      // configured in JavaScript, before executing Dart. Now add the full set of
+      // supported Firebase pacakges. This workaround is a very fragile hack.
+      packages = {
+        ...supportedBasicDartPackages,
+        ...supportedFlutterPackages,
+        ...firebasePackages,
+      };
+      final dependencies = _dependencyVersions(packages);
+      File(path.join(projectPath, 'pubspec.yaml'))
+          .writeAsStringSync(createPubspec(
+        includeFlutterWeb: true,
+        nullSafety: _isNullSafe,
+        dependencies: dependencies,
+      ));
+      await _runDartPubGet(projectDir);
+    }
+    File(path.join(projectPath, 'analysis_options.yaml')).writeAsStringSync('''
+include: package:flutter_lints/flutter.yaml
+linter:
+  rules:
+    avoid_print: false
+    use_key_in_widget_constructors: false
+''');
+  }
+
+  Future<void> _runDartPubGet(Directory dir) async {
+    final process = await runWithLogging(
+      path.join(_dartSdkPath, 'bin', 'dart'),
+      arguments: ['pub', 'get'],
+      workingDirectory: dir.path,
+      environment: {'PUB_CACHE': _pubCachePath},
+      log: _log,
+    );
+    await process.exitCode;
+  }
+
+  Map<String, String> _dependencyVersions(
+    Iterable<String> packages,
+  ) {
+    final allVersions =
+        parsePubDependenciesFile(dependenciesFile: _dependenciesFile);
+    return {
+      for (var package in packages) package: allVersions[package] ?? 'any',
+    };
+  }
+}
+
+/// Parses [dependenciesFile] as a JSON Map of Strings.
+Map<String, String> parsePubDependenciesFile({required File dependenciesFile}) {
+  final packageVersions =
+      jsonDecode(dependenciesFile.readAsStringSync()) as Map;
+  return packageVersions.cast<String, String>();
+}
+
+/// Build a return a `pubspec.yaml` file.
+String createPubspec({
+  required bool includeFlutterWeb,
+  required bool nullSafety,
+  Map<String, String> dependencies = const {},
+}) {
+  var content = '''
+name: dartpad_sample
+environment:
+  sdk: '>=${nullSafety ? '2.14.0' : '2.10.0'} <3.0.0'
+dependencies:
+''';
+
+  if (includeFlutterWeb) {
+    content += '''
+  flutter:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
+''';
+  }
+  dependencies.forEach((name, version) {
+    content += '  $name: $version\n';
+  });
+
+  return content;
+}
+
+Future<void> runFlutterPackagesGet(
+  String flutterToolPath,
+  String projectPath, {
+  required LogFunction log,
+}) async {
+  final process = await runWithLogging(flutterToolPath,
+      arguments: ['packages', 'get'],
+      workingDirectory: projectPath,
+      environment: {'PUB_CACHE': _pubCachePath},
+      log: log);
+  await process.exitCode;
+}
+
+/// Builds the local pub cache directory and returns the path.
+String get _pubCachePath {
+  final pubCachePath = path.join(Directory.current.path, 'local_pub_cache');
+  Directory(pubCachePath).createSync();
+  return pubCachePath;
+}
+
+enum FirebaseStyle {
+  /// Indicates that no Firebase is used.
+  none,
+
+  /// Indicates that the deprecated Firebase packages are used.
+  deprecated,
+
+  /// Indicates that the "pure Dart" Flutterfire packages are used.
+  flutterFire,
+}

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -31,7 +31,7 @@ class Sdk {
   final String version;
 
   factory Sdk.create(String channel) {
-    final sdkPath = path.join(Sdk.flutterSdksPath, channel);
+    final sdkPath = path.join(Sdk._flutterSdksPath, channel);
     final flutterBinPath = path.join(sdkPath, 'bin');
     final dartSdkPath = path.join(flutterBinPath, 'cache', 'dart-sdk');
     return _instance ??= Sdk._(
@@ -63,7 +63,7 @@ class Sdk {
       (File(path.join(filePath, 'version')).readAsStringSync()).trim();
 
   /// Get the path to the Flutter SDKs.
-  static String get flutterSdksPath =>
+  static String get _flutterSdksPath =>
       path.join(Directory.current.path, 'flutter-sdks');
 }
 
@@ -127,7 +127,7 @@ class DownloadingSdkManager {
   }
 
   Future<_DownloadedFlutterSdk> _cloneSdkIfNecessary(String channel) async {
-    final sdkPath = path.join(Sdk.flutterSdksPath, channel);
+    final sdkPath = path.join(Sdk._flutterSdksPath, channel);
     final sdk = _DownloadedFlutterSdk(sdkPath);
 
     if (!Directory(sdk.flutterSdkPath).existsSync()) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as path;
 
 /// Normalizes any "paths" from [text], replacing the segments before the last
@@ -39,6 +41,29 @@ String normalizeFilePaths(String text) {
 
     return basename;
   });
+}
+
+Future<Process> runWithLogging(
+  String executable, {
+  List<String> arguments = const [],
+  String? workingDirectory,
+  Map<String, String> environment = const {},
+  required void Function(String) log,
+}) async {
+  log([
+    'Running $executable ${arguments.join(' ')}',
+    if (workingDirectory != null) "from directory: '$workingDirectory'",
+    if (environment.isNotEmpty) 'with additional environment: $environment',
+  ].join('\n  '));
+
+  final process = await Process.start(executable, arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: true,
+      runInShell: Platform.isWindows);
+  process.stdout.listen((out) => log(systemEncoding.decode(out)));
+  process.stderr.listen((err) => log(systemEncoding.decode(err)));
+  return process;
 }
 
 /// A pattern which matches a possible path.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -505,6 +505,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.5"
+  test_descriptor:
+    dependency: "direct dev"
+    description:
+      name: test_descriptor
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dev_dependencies:
   shelf_router_generator: ^1.0.0
   synchronized: ^3.0.0
   test: ^1.6.4
+  test_descriptor: ^2.0.0
 
 executables:
   services: null

--- a/test/all.dart
+++ b/test/all.dart
@@ -14,6 +14,7 @@ import 'compiler_test.dart' as compiler_test;
 import 'flutter_analysis_server_test.dart' as flutter_analysis_server_test;
 import 'flutter_web_test.dart' as flutter_web_test;
 import 'gae_deployed_test.dart' as gae_deployed_test;
+import 'project_creator_test.dart' as project_creator_test;
 import 'pub_test.dart' as pub_test;
 import 'redis_cache_test.dart' as redis_test;
 import 'shelf_cors_test.dart' as shelf_cors_test;
@@ -28,6 +29,7 @@ void main() async {
   flutter_analysis_server_test.defineTests();
   flutter_web_test.defineTests();
   gae_deployed_test.defineTests();
+  project_creator_test.defineTests();
   pub_test.defineTests();
   redis_test.defineTests();
   shelf_cors_test.defineTests();

--- a/test/project_creator_test.dart
+++ b/test/project_creator_test.dart
@@ -1,0 +1,327 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:dart_services/src/project_creator.dart';
+import 'package:dart_services/src/sdk.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+final channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
+
+void main() => defineTests();
+
+void defineTests() {
+  Future<ProjectCreator> projectCreator() async {
+    final dependenciesFile = d.file('dependencies.json', '''
+{
+  "meta": "1.7.0"
+}
+''');
+    await dependenciesFile.create();
+    final templatesPath = d.dir('project_templates');
+    await templatesPath.create();
+    final sdk = Sdk.create('stable');
+    return ProjectCreator(
+      sdk,
+      templatesPath.io.path,
+      isNullSafe: true,
+      dependenciesFile: dependenciesFile.io,
+      log: (_) {},
+    );
+  }
+
+  group('basic dart project template, null safe', () {
+    setUpAll(() async {
+      await (await projectCreator()).buildDartProjectTemplate();
+    });
+
+    test('project directory is created', () async {
+      await d.dir('project_templates', [
+        d.dir('null-safe', [
+          d.dir('dart_project'),
+        ]),
+      ]).validate();
+    });
+
+    test('pubspec is created', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('dart_project', [
+          d.file(
+              'pubspec.yaml',
+              allOf([
+                matches("sdk: '>=2.14.0 <3.0.0'"),
+                matches('meta: 1.7.0'),
+              ])),
+        ]),
+      ]).validate();
+    });
+
+    test('pub get creates pubspec.lock', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('dart_project', [d.file('pubspec.lock', isNotEmpty)]),
+      ]).validate();
+    });
+
+    test('recommended lints are enabled', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('dart_project', [
+          d.file('analysis_options.yaml',
+              matches('include: package:lints/recommended.yaml')),
+        ]),
+      ]).validate();
+    });
+  });
+
+  group('basic dart project template, pre-null safe', () {
+    setUpAll(() async {
+      final dependenciesFile = d.file('dependencies.json', '''
+{
+  "meta": "1.7.0"
+}
+''');
+      await dependenciesFile.create();
+      final templatesPath = d.dir('project_templates');
+      await templatesPath.create();
+      final sdk = Sdk.create('stable');
+      final projectCreator = ProjectCreator(
+        sdk,
+        templatesPath.io.path,
+        isNullSafe: false,
+        dependenciesFile: dependenciesFile.io,
+        log: (_) {},
+      );
+      await projectCreator.buildDartProjectTemplate();
+    });
+
+    test('project directory is created', () async {
+      await d.dir('project_templates', [
+        d.dir('null-unsafe', [
+          d.dir('dart_project'),
+        ]),
+      ]).validate();
+    });
+
+    test('pubspec is created', () async {
+      await d.dir('project_templates/null-unsafe', [
+        d.dir('dart_project', [
+          d.file(
+              'pubspec.yaml',
+              allOf([
+                matches("sdk: '>=2.10.0 <3.0.0'"),
+                matches('meta: 1.7.0'),
+              ])),
+        ]),
+      ]).validate();
+    });
+  });
+
+  group('basic Flutter project template', () {
+    setUpAll(() async {
+      await (await projectCreator())
+          .buildFlutterProjectTemplate(firebaseStyle: FirebaseStyle.none);
+    });
+
+    test('project directory is created', () async {
+      await d.dir('project_templates', [
+        d.dir('null-safe', [
+          d.dir('flutter_project'),
+        ]),
+      ]).validate();
+    });
+
+    test('Flutter Web directories are created', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('flutter_project', [
+          d.dir('lib'),
+          d.dir('web', [d.file('index.html', isEmpty)]),
+        ])
+      ]).validate();
+    });
+
+    test('pubspec is created', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('flutter_project', [
+          d.file(
+              'pubspec.yaml',
+              allOf([
+                matches("sdk: '>=2.14.0 <3.0.0'"),
+                matches('meta: 1.7.0'),
+                matches('sdk: flutter'),
+              ])),
+        ]),
+      ]).validate();
+    });
+
+    test('pub get creates pubspec.lock', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('flutter_project', [d.file('pubspec.lock', isNotEmpty)]),
+      ]).validate();
+    });
+
+    test('flutter lints are enabled', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('flutter_project', [
+          d.file('analysis_options.yaml',
+              matches('include: package:flutter_lints/flutter.yaml')),
+        ]),
+      ]).validate();
+    });
+
+    test('plugins are registered', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('flutter_project/lib', [
+          d.file('generated_plugin_registrant.dart',
+              matches('UrlLauncherPlugin.registerWith')),
+        ]),
+      ]).validate();
+    });
+  });
+
+  group('Firebase project template', () {
+    setUpAll(() async {
+      await (await projectCreator()).buildFlutterProjectTemplate(
+          firebaseStyle: FirebaseStyle.flutterFire);
+    });
+
+    test('project directory is created', () async {
+      await d.dir('project_templates', [
+        d.dir('null-safe', [
+          d.dir('firebase_project'),
+        ]),
+      ]).validate();
+    });
+
+    test('Flutter Web directories are created', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_project', [
+          d.dir('lib'),
+          d.dir('web', [d.file('index.html', isEmpty)]),
+        ])
+      ]).validate();
+    });
+
+    test('pubspec is created', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_project', [
+          d.file(
+              'pubspec.yaml',
+              allOf([
+                matches("sdk: '>=2.14.0 <3.0.0'"),
+                matches('meta: 1.7.0'),
+                matches('sdk: flutter'),
+              ])),
+        ]),
+      ]).validate();
+    });
+
+    test('pub get creates pubspec.lock', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_project', [d.file('pubspec.lock', isNotEmpty)]),
+      ]).validate();
+    });
+
+    test('flutter lints are enabled', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_project', [
+          d.file('analysis_options.yaml',
+              matches('include: package:flutter_lints/flutter.yaml')),
+        ]),
+      ]).validate();
+    });
+
+    test('plugins are registered', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_project/lib', [
+          d.file(
+              'generated_plugin_registrant.dart',
+              allOf([
+                matches('FirebaseFirestoreWeb.registerWith'),
+                matches('FirebaseFunctionsWeb.registerWith'),
+                matches('FirebaseFunctionsWeb.registerWith'),
+                matches('FirebaseAuthWeb.registerWith'),
+                matches('FirebaseCoreWeb.registerWith'),
+                matches('FirebaseDatabaseWeb.registerWith'),
+                matches('FirebaseStorageWeb.registerWith'),
+                matches('UrlLauncherPlugin.registerWith'),
+              ])),
+        ]),
+      ]).validate();
+    });
+  });
+
+  group('deprecated Firebase project template', () {
+    setUpAll(() async {
+      await (await projectCreator())
+          .buildFlutterProjectTemplate(firebaseStyle: FirebaseStyle.deprecated);
+    });
+
+    test('project directory is created', () async {
+      await d.dir('project_templates', [
+        d.dir('null-safe', [
+          d.dir('firebase_deprecated_project'),
+        ]),
+      ]).validate();
+    });
+
+    test('Flutter Web directories are created', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_deprecated_project', [
+          d.dir('lib'),
+          d.dir('web', [d.file('index.html', isEmpty)]),
+        ])
+      ]).validate();
+    });
+
+    test('pubspec is created', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_deprecated_project', [
+          d.file(
+              'pubspec.yaml',
+              allOf([
+                matches("sdk: '>=2.14.0 <3.0.0'"),
+                matches('meta: 1.7.0'),
+                matches('sdk: flutter'),
+              ])),
+        ]),
+      ]).validate();
+    });
+
+    test('pub get creates pubspec.lock', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_deprecated_project',
+            [d.file('pubspec.lock', isNotEmpty)]),
+      ]).validate();
+    });
+
+    test('flutter lints are enabled', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_deprecated_project', [
+          d.file('analysis_options.yaml',
+              matches('include: package:flutter_lints/flutter.yaml')),
+        ]),
+      ]).validate();
+    });
+
+    test('plugins are registered', () async {
+      await d.dir('project_templates/null-safe', [
+        d.dir('firebase_deprecated_project/lib', [
+          d.file(
+              'generated_plugin_registrant.dart',
+              allOf([
+                isNot(matches('FirebaseFirestoreWeb.registerWith')),
+                isNot(matches('FirebaseFunctionsWeb.registerWith')),
+                isNot(matches('FirebaseFunctionsWeb.registerWith')),
+                isNot(matches('FirebaseAuthWeb.registerWith')),
+                matches('FirebaseCoreWeb.registerWith'),
+                isNot(matches('FirebaseDatabaseWeb.registerWith')),
+                isNot(matches('FirebaseStorageWeb.registerWith')),
+                matches('UrlLauncherPlugin.registerWith'),
+              ])),
+        ]),
+      ]).validate();
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces tests for the grinder task which creates project templates. In order to make these sandboxed(-ish) tests, I extracted a lot of code from `tool/grind.dart` into `lib/src/project_creator.dart` and a class, ProjectCreator, and then used the test_descriptor pub package for sandboxed directory testing.

The amount of code which was moved to lib/ I think really justifies the testing: this grinder task had some real complexity, and it's good to put that in a testable location.