### PR TITLE
Add retry logic to flaky analysis tests

### DIFF
--- a/test/common_server_api_protobuf_test.dart
+++ b/test/common_server_api_protobuf_test.dart
@@ -20,6 +20,8 @@ import 'package:protobuf/protobuf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 const quickFixesCode = r'''
 import 'dart:async';
 void main() {
@@ -84,23 +86,6 @@ void defineTests() {
     await request.close();
     await shelf_io.handleRequest(request, commonServerApi.router);
     return request.response;
-  }
-
-  Future<void> tryWithReruns(FutureOr<void> Function() fn) async {
-    for (var i = 0; i < 3; i++) {
-      try {
-        await fn();
-        // If the function returns normally, continue.
-        return;
-      } catch (e) {
-        print('Setup function threw: $e;');
-        if (i < 2) {
-          print('Retrying...');
-        } else {
-          rethrow;
-        }
-      }
-    }
   }
 
   group('CommonServerProto JSON', () {

--- a/test/common_server_api_protobuf_test.dart
+++ b/test/common_server_api_protobuf_test.dart
@@ -96,6 +96,8 @@ void defineTests() {
         print('Setup function threw: $e;');
         if (i < 2) {
           print('Retrying...');
+        } else {
+          rethrow;
         }
       }
     }

--- a/test/common_server_api_protobuf_test.dart
+++ b/test/common_server_api_protobuf_test.dart
@@ -92,8 +92,11 @@ void defineTests() {
         await fn();
         // If the function returns normally, continue.
         return;
-      } catch (_) {
-        // Retry.
+      } catch (e) {
+        print('Setup function threw: $e;');
+        if (i < 2) {
+          print('Retrying...');
+        }
       }
     }
   }

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -99,6 +99,8 @@ void defineTests() {
         print('Setup function threw: $e;');
         if (i < 2) {
           print('Retrying...');
+        } else {
+          rethrow;
         }
       }
     }

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -63,7 +63,7 @@ void defineTests() {
   MockContainer container;
   MockCache cache;
 
-  Future<MockHttpResponse> _sendPostRequest(
+  Future<MockHttpResponse> sendPostRequest(
     String path,
     dynamic jsonData,
   ) async {
@@ -77,7 +77,7 @@ void defineTests() {
     return request.response;
   }
 
-  Future<MockHttpResponse> _sendGetRequest(
+  Future<MockHttpResponse> sendGetRequest(
     String path,
   ) async {
     assert(commonServerApi != null);
@@ -87,6 +87,18 @@ void defineTests() {
     await request.close();
     await shelf_io.handleRequest(request, commonServerApi!.router);
     return request.response;
+  }
+
+  Future<void> tryWithReruns(FutureOr<void> Function() fn) async {
+    for (var i = 0; i < 3; i++) {
+      try {
+        await fn();
+        // If the function returns normally, continue.
+        return;
+      } catch (_) {
+        // Retry.
+      }
+    }
   }
 
   group('CommonServerProto JSON', () {
@@ -109,7 +121,7 @@ void defineTests() {
         final jsonData = {'source': sampleCodeError};
         while (decodedJson.isEmpty) {
           final response =
-              await _sendPostRequest('dartservices/v2/analyze', jsonData);
+              await sendPostRequest('dartservices/v2/analyze', jsonData);
           expect(response.statusCode, 200);
           expect(response.headers['content-type'],
               ['application/json; charset=utf-8']);
@@ -135,7 +147,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': sampleCode};
         final response =
-            await _sendPostRequest('dartservices/$version/analyze', jsonData);
+            await sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 200);
         final data = await response.transform(utf8.decoder).join();
         expect(json.decode(data), <dynamic, dynamic>{});
@@ -146,7 +158,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': sampleCodeFlutter};
         final response =
-            await _sendPostRequest('dartservices/$version/analyze', jsonData);
+            await sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 200);
         final data = await response.transform(utf8.decoder).join();
         expect(json.decode(data), {
@@ -159,7 +171,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': sampleCodeFlutterCounter};
         final response =
-            await _sendPostRequest('dartservices/$version/analyze', jsonData);
+            await sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 200);
         final data = await response.transform(utf8.decoder).join();
         expect(json.decode(data), {
@@ -172,7 +184,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': sampleCodeFlutterDraggableCard};
         final response =
-            await _sendPostRequest('dartservices/$version/analyze', jsonData);
+            await sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 200);
         final data = await response.transform(utf8.decoder).join();
         expect(json.decode(data), {
@@ -184,26 +196,35 @@ void defineTests() {
     test('analyze errors', () async {
       for (final version in versions) {
         final jsonData = {'source': sampleCodeError};
-        final response =
-            await _sendPostRequest('dartservices/$version/analyze', jsonData);
-        expect(response.statusCode, 200);
-        expect(response.headers['content-type'],
-            ['application/json; charset=utf-8']);
-        final data = await response.transform(utf8.decoder).join();
-        final expectedJson = {
-          'issues': [
-            {
-              'kind': 'error',
-              'line': 2,
-              'sourceName': 'main.dart',
-              'message': "Expected to find ';'.",
-              'hasFixes': true,
-              'charStart': 29,
-              'charLength': 1
-            }
-          ]
-        };
-        expect(json.decode(data), expectedJson);
+        late Map<String, Object> dataMap;
+        await tryWithReruns(() async {
+          final response =
+              await sendPostRequest('dartservices/$version/analyze', jsonData);
+          expect(response.statusCode, 200);
+          expect(response.headers['content-type'],
+              ['application/json; charset=utf-8']);
+          final data = await response.transform(utf8.decoder).join();
+          dataMap = (json.decode(data) as Map).cast<String, Object>();
+          if (dataMap.isEmpty) {
+            throw StateError('Flaky result');
+          }
+        });
+        expect(
+          dataMap,
+          {
+            'issues': [
+              {
+                'kind': 'error',
+                'line': 2,
+                'sourceName': 'main.dart',
+                'message': "Expected to find ';'.",
+                'hasFixes': true,
+                'charStart': 29,
+                'charLength': 1,
+              }
+            ]
+          },
+        );
       }
     });
 
@@ -211,7 +232,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = <dynamic, dynamic>{};
         final response =
-            await _sendPostRequest('dartservices/$version/analyze', jsonData);
+            await sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 400);
       }
     });
@@ -220,7 +241,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': sampleCode};
         final response =
-            await _sendPostRequest('dartservices/$version/compile', jsonData);
+            await sendPostRequest('dartservices/$version/compile', jsonData);
         expect(response.statusCode, 200);
         final data = await response.transform(utf8.decoder).join();
         expect(json.decode(data), isNotEmpty);
@@ -231,13 +252,13 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': sampleCode};
         final response1 =
-            await _sendPostRequest('dartservices/$version/compile', jsonData);
+            await sendPostRequest('dartservices/$version/compile', jsonData);
         expect(response1.statusCode, 200);
         final data1 = await response1.transform(utf8.decoder).join();
         expect(json.decode(data1), isNotEmpty);
 
         final response2 =
-            await _sendPostRequest('dartservices/$version/compile', jsonData);
+            await sendPostRequest('dartservices/$version/compile', jsonData);
         expect(response2.statusCode, 200);
         final data2 = await response2.transform(utf8.decoder).join();
         expect(json.decode(data2), isNotEmpty);
@@ -248,7 +269,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': sampleCodeError};
         final response =
-            await _sendPostRequest('dartservices/$version/compile', jsonData);
+            await sendPostRequest('dartservices/$version/compile', jsonData);
         expect(response.statusCode, 400);
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;
@@ -262,7 +283,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = <dynamic, dynamic>{};
         final response =
-            await _sendPostRequest('dartservices/$version/compile', jsonData);
+            await sendPostRequest('dartservices/$version/compile', jsonData);
         expect(response.statusCode, 400);
       }
     });
@@ -270,8 +291,8 @@ void defineTests() {
     test('compileDDC', () async {
       for (final version in versions) {
         final jsonData = {'source': sampleCode};
-        final response = await _sendPostRequest(
-            'dartservices/$version/compileDDC', jsonData);
+        final response =
+            await sendPostRequest('dartservices/$version/compileDDC', jsonData);
         expect(response.statusCode, 200);
         final data = await response.transform(utf8.decoder).join();
         expect(json.decode(data), isNotEmpty);
@@ -281,14 +302,14 @@ void defineTests() {
     test('compileDDC with cache', () async {
       for (final version in versions) {
         final jsonData = {'source': sampleCode};
-        final response1 = await _sendPostRequest(
-            'dartservices/$version/compileDDC', jsonData);
+        final response1 =
+            await sendPostRequest('dartservices/$version/compileDDC', jsonData);
         expect(response1.statusCode, 200);
         final data1 = await response1.transform(utf8.decoder).join();
         expect(json.decode(data1), isNotEmpty);
 
-        final response2 = await _sendPostRequest(
-            'dartservices/$version/compileDDC', jsonData);
+        final response2 =
+            await sendPostRequest('dartservices/$version/compileDDC', jsonData);
         expect(response2.statusCode, 200);
         final data2 = await response2.transform(utf8.decoder).join();
         expect(json.decode(data2), isNotEmpty);
@@ -299,7 +320,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': 'void main() {print("foo");}', 'offset': 1};
         final response =
-            await _sendPostRequest('dartservices/$version/complete', jsonData);
+            await sendPostRequest('dartservices/$version/complete', jsonData);
         expect(response.statusCode, 200);
         final data = json.decode(await response.transform(utf8.decoder).join());
         expect(data, isNotEmpty);
@@ -308,7 +329,7 @@ void defineTests() {
 
     test('complete no data', () async {
       for (final version in versions) {
-        final response = await _sendPostRequest(
+        final response = await sendPostRequest(
             'dartservices/$version/complete', <dynamic, dynamic>{});
         expect(response.statusCode, 400);
       }
@@ -318,7 +339,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'offset': 1};
         final response =
-            await _sendPostRequest('dartservices/$version/complete', jsonData);
+            await sendPostRequest('dartservices/$version/complete', jsonData);
         expect(response.statusCode, 400);
       }
     });
@@ -327,7 +348,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': 'void main() {print("foo");}'};
         final response =
-            await _sendPostRequest('dartservices/$version/complete', jsonData);
+            await sendPostRequest('dartservices/$version/complete', jsonData);
         expect(response.statusCode, 400);
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;
@@ -343,7 +364,7 @@ void defineTests() {
           'offset': 17
         };
         final response =
-            await _sendPostRequest('dartservices/$version/document', jsonData);
+            await sendPostRequest('dartservices/$version/document', jsonData);
         expect(response.statusCode, 200);
         final data = json.decode(await response.transform(utf8.decoder).join());
         expect(data, isNotEmpty);
@@ -354,7 +375,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': 'void main() {print("foo");}', 'offset': 2};
         final response =
-            await _sendPostRequest('dartservices/$version/document', jsonData);
+            await sendPostRequest('dartservices/$version/document', jsonData);
         expect(response.statusCode, 200);
         final data = json.decode(await response.transform(utf8.decoder).join());
         expect(data, {
@@ -370,7 +391,7 @@ void defineTests() {
           'offset': 12
         };
         final response =
-            await _sendPostRequest('dartservices/$version/document', jsonData);
+            await sendPostRequest('dartservices/$version/document', jsonData);
         expect(response.statusCode, 200);
         final data = json.decode(await response.transform(utf8.decoder).join());
         expect(data, {'info': <dynamic, dynamic>{}});
@@ -381,7 +402,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'offset': 12};
         final response =
-            await _sendPostRequest('dartservices/$version/document', jsonData);
+            await sendPostRequest('dartservices/$version/document', jsonData);
         expect(response.statusCode, 400);
       }
     });
@@ -390,7 +411,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': 'void main() {print("foo");}'};
         final response =
-            await _sendPostRequest('dartservices/$version/document', jsonData);
+            await sendPostRequest('dartservices/$version/document', jsonData);
         expect(response.statusCode, 400);
       }
     });
@@ -399,7 +420,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': preFormattedCode};
         final response =
-            await _sendPostRequest('dartservices/$version/format', jsonData);
+            await sendPostRequest('dartservices/$version/format', jsonData);
         expect(response.statusCode, 200);
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;
@@ -411,7 +432,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': formatBadCode};
         final response =
-            await _sendPostRequest('dartservices/$version/format', jsonData);
+            await sendPostRequest('dartservices/$version/format', jsonData);
         expect(response.statusCode, 200);
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;
@@ -423,7 +444,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': preFormattedCode, 'offset': 21};
         final response =
-            await _sendPostRequest('dartservices/$version/format', jsonData);
+            await sendPostRequest('dartservices/$version/format', jsonData);
         expect(response.statusCode, 200);
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;
@@ -436,7 +457,7 @@ void defineTests() {
       for (final version in versions) {
         final jsonData = {'source': quickFixesCode, 'offset': 10};
         final response =
-            await _sendPostRequest('dartservices/$version/fixes', jsonData);
+            await sendPostRequest('dartservices/$version/fixes', jsonData);
         expect(response.statusCode, 200);
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;
@@ -460,7 +481,7 @@ void main() {
           'offset': 67,
         };
         final response =
-            await _sendPostRequest('dartservices/$version/fixes', jsonData);
+            await sendPostRequest('dartservices/$version/fixes', jsonData);
         expect(response.statusCode, 200);
         final data = json.decode(await response.transform(utf8.decoder).join());
         expect(data, {
@@ -487,7 +508,7 @@ void main() {
       for (final version in versions) {
         final jsonData = {'source': assistCode, 'offset': 15};
         final response =
-            await _sendPostRequest('dartservices/$version/assists', jsonData);
+            await sendPostRequest('dartservices/$version/assists', jsonData);
         expect(response.statusCode, 200);
 
         final encoded = await response.transform(utf8.decoder).join();
@@ -506,7 +527,7 @@ void main() {
 
     test('version', () async {
       for (final version in versions) {
-        final response = await _sendGetRequest('dartservices/$version/version');
+        final response = await sendGetRequest('dartservices/$version/version');
         expect(response.statusCode, 200);
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -19,6 +19,8 @@ import 'package:logging/logging.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 const versions = ['v1', 'v2'];
 
 const quickFixesCode = r'''
@@ -87,23 +89,6 @@ void defineTests() {
     await request.close();
     await shelf_io.handleRequest(request, commonServerApi!.router);
     return request.response;
-  }
-
-  Future<void> tryWithReruns(FutureOr<void> Function() fn) async {
-    for (var i = 0; i < 3; i++) {
-      try {
-        await fn();
-        // If the function returns normally, continue.
-        return;
-      } catch (e) {
-        print('Setup function threw: $e;');
-        if (i < 2) {
-          print('Retrying...');
-        } else {
-          rethrow;
-        }
-      }
-    }
   }
 
   group('CommonServerProto JSON', () {

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -95,8 +95,11 @@ void defineTests() {
         await fn();
         // If the function returns normally, continue.
         return;
-      } catch (_) {
-        // Retry.
+      } catch (e) {
+        print('Setup function threw: $e;');
+        if (i < 2) {
+          print('Retrying...');
+        }
       }
     }
   }

--- a/test/flutter_analysis_server_test.dart
+++ b/test/flutter_analysis_server_test.dart
@@ -105,7 +105,9 @@ class HelloWorld extends StatelessWidget {
 
       // https://github.com/dart-lang/dart-pad/issues/2005
       test('reports lint with Flutter code', () async {
-        final results = await analysisServersWrapper.analyze('''
+        late AnalysisResults results;
+        await tryWithReruns(() async {
+          results = await analysisServersWrapper.analyze('''
 import 'package:flutter/material.dart';
 
 void main() async {
@@ -121,6 +123,10 @@ class HelloWorld extends StatelessWidget {
   Widget build(context) => const Center(child: Text('Hello world'));
 }
 ''');
+          if (results.issues.isEmpty) {
+            throw StateError('Flaky result');
+          }
+        });
         expect(results.issues, hasLength(1));
         final issue = results.issues[0];
         expect(issue.line, 4);

--- a/test/flutter_analysis_server_test.dart
+++ b/test/flutter_analysis_server_test.dart
@@ -15,6 +15,8 @@ import 'package:dart_services/src/sdk.dart';
 import 'package:dart_services/src/server_cache.dart';
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 final channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
 void main() => defineTests();
 
@@ -69,7 +71,9 @@ void defineTests() {
       });
 
       test('reports errors with Flutter code', () async {
-        final results = await analysisServersWrapper.analyze('''
+        late AnalysisResults results;
+        await tryWithReruns(() async {
+          results = await analysisServersWrapper.analyze('''
 import 'package:flutter/material.dart';
 
 String x = 7;
@@ -85,6 +89,10 @@ class HelloWorld extends StatelessWidget {
   Widget build(context) => const Center(child: Text('Hello world'));
 }
 ''');
+          if (results.issues.isEmpty) {
+            throw StateError('Flaky result');
+          }
+        });
         expect(results.issues, hasLength(1));
         final issue = results.issues[0];
         expect(issue.line, 3);

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+/// Runs [fn] up to three times, catching thrown exceptions, until it returns
+/// normally.
+Future<void> tryWithReruns(FutureOr<void> Function() fn) async {
+  for (var i = 0; i < 3; i++) {
+    try {
+      await fn();
+      // If the function returns normally, continue.
+      return;
+    } catch (e) {
+      print('Setup function threw: $e;');
+      if (i < 2) {
+        print('Retrying...');
+      } else {
+        rethrow;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Work related to https://github.com/dart-lang/dart-pad/issues/2027

I think the analysis server client implementation has a real flake feature to it, and I'm working on a big refactoring in a branch. I don't think we should land it until after any upcoming conferences though; in the meantime, I'd like to add this retry logic.