### PR TITLE
Use individual Dart Language Versions for each channel

### DIFF
--- a/flutter-sdk-version.yaml
+++ b/flutter-sdk-version.yaml
@@ -11,10 +11,14 @@ flutter_sdk:
     dart_language_version: 2.14.0
   beta:
     flutter_version: 2.7.0-3.0.pre
-    dart_language_version: 2.15.0
+    dart_language_version: 2.15.0-0
+    enabled_experiments:
+      - constructor-tearoffs
   dev:
     flutter_version: 2.6.0-11.0.pre
-    dart_language_version: 2.15.0
+    dart_language_version: 2.15.0-0
+    enabled_experiments:
+      - constructor-tearoffs
   old:
     flutter_version: 2.5.1
-    dart_language_version: 2.14.0
+    dart_language_version: 2.13.0

--- a/flutter-sdk-version.yaml
+++ b/flutter-sdk-version.yaml
@@ -6,7 +6,15 @@
 # In order to update the SDK manually, run 'dart tool/update_sdk.dart'.
 
 flutter_sdk:
-  stable_version: 2.5.3
-  beta_version: 2.7.0-3.0.pre
-  dev_version: 2.6.0-11.0.pre
-  old_version: 2.5.1
+  stable:
+    flutter_version: 2.5.3
+    dart_language_version: 2.14.0
+  beta:
+    flutter_version: 2.7.0-3.0.pre
+    dart_language_version: 2.15.0
+  dev:
+    flutter_version: 2.6.0-11.0.pre
+    dart_language_version: 2.15.0
+  old:
+    flutter_version: 2.5.1
+    dart_language_version: 2.14.0

--- a/flutter-sdk-version.yaml
+++ b/flutter-sdk-version.yaml
@@ -12,13 +12,9 @@ flutter_sdk:
   beta:
     flutter_version: 2.7.0-3.0.pre
     dart_language_version: 2.15.0-0
-    enabled_experiments:
-      - constructor-tearoffs
   dev:
     flutter_version: 2.6.0-11.0.pre
     dart_language_version: 2.15.0-0
-    enabled_experiments:
-      - constructor-tearoffs
   old:
     flutter_version: 2.5.1
     dart_language_version: 2.13.0

--- a/lib/src/project_creator.dart
+++ b/lib/src/project_creator.dart
@@ -21,6 +21,9 @@ class ProjectCreator {
 
   final bool _isNullSafe;
 
+  /// The Dart Language Version to use for code using null safety.
+  final String _dartLanguageVersion;
+
   final File _dependenciesFile;
 
   final LogFunction _log;
@@ -29,11 +32,13 @@ class ProjectCreator {
     Sdk sdk,
     this._templatesPath, {
     required bool isNullSafe,
+    required String dartLanguageVersion,
     required File dependenciesFile,
     required LogFunction log,
   })  : _dartSdkPath = sdk.dartSdkPath,
         _flutterToolPath = sdk.flutterToolPath,
         _isNullSafe = isNullSafe,
+        _dartLanguageVersion = dartLanguageVersion,
         _dependenciesFile = dependenciesFile,
         _log = log;
 
@@ -49,6 +54,7 @@ class ProjectCreator {
         .writeAsStringSync(createPubspec(
       includeFlutterWeb: false,
       nullSafety: _isNullSafe,
+      dartLanguageVersion: _dartLanguageVersion,
       dependencies: dependencies,
     ));
     await _runDartPubGet(projectDirectory);
@@ -97,6 +103,7 @@ linter:
         .writeAsStringSync(createPubspec(
       includeFlutterWeb: true,
       nullSafety: _isNullSafe,
+      dartLanguageVersion: _dartLanguageVersion,
       dependencies: dependencies,
     ));
     await runFlutterPackagesGet(_flutterToolPath, projectPath, log: _log);
@@ -115,6 +122,7 @@ linter:
           .writeAsStringSync(createPubspec(
         includeFlutterWeb: true,
         nullSafety: _isNullSafe,
+        dartLanguageVersion: _dartLanguageVersion,
         dependencies: dependencies,
       ));
       await _runDartPubGet(projectDir);
@@ -161,12 +169,13 @@ Map<String, String> parsePubDependenciesFile({required File dependenciesFile}) {
 String createPubspec({
   required bool includeFlutterWeb,
   required bool nullSafety,
+  required String dartLanguageVersion,
   Map<String, String> dependencies = const {},
 }) {
   var content = '''
 name: dartpad_sample
 environment:
-  sdk: '>=${nullSafety ? '2.14.0' : '2.10.0'} <3.0.0'
+  sdk: '>=${nullSafety ? dartLanguageVersion : '2.10.0'} <3.0.0'
 dependencies:
 ''';
 

--- a/lib/src/project_creator.dart
+++ b/lib/src/project_creator.dart
@@ -24,6 +24,8 @@ class ProjectCreator {
   /// The Dart Language Version to use for code using null safety.
   final String _dartLanguageVersion;
 
+  final List<String> _enabledExperiments;
+
   final File _dependenciesFile;
 
   final LogFunction _log;
@@ -33,12 +35,14 @@ class ProjectCreator {
     this._templatesPath, {
     required bool isNullSafe,
     required String dartLanguageVersion,
+    required List<String> enabledExperiments,
     required File dependenciesFile,
     required LogFunction log,
   })  : _dartSdkPath = sdk.dartSdkPath,
         _flutterToolPath = sdk.flutterToolPath,
         _isNullSafe = isNullSafe,
         _dartLanguageVersion = dartLanguageVersion,
+        _enabledExperiments = enabledExperiments,
         _dependenciesFile = dependenciesFile,
         _log = log;
 
@@ -60,11 +64,17 @@ class ProjectCreator {
     await _runDartPubGet(projectDirectory);
     File(path.join(projectPath, 'analysis_options.yaml')).writeAsStringSync('''
 include: package:lints/recommended.yaml
+analyzer:
+  enable-experiment:
+$_enabledExperimentsYaml
 linter:
   rules:
     avoid_print: false
 ''');
   }
+
+  String get _enabledExperimentsYaml =>
+      _enabledExperiments.map((e) => '    - $e').join('\n');
 
   /// Builds a Flutter project template directory, complete with `pubspec.yaml`,
   /// `analysis_options.yaml`, and `web/index.html`.

--- a/lib/src/project_creator.dart
+++ b/lib/src/project_creator.dart
@@ -24,8 +24,6 @@ class ProjectCreator {
   /// The Dart Language Version to use for code using null safety.
   final String _dartLanguageVersion;
 
-  final List<String> _enabledExperiments;
-
   final File _dependenciesFile;
 
   final LogFunction _log;
@@ -35,14 +33,12 @@ class ProjectCreator {
     this._templatesPath, {
     required bool isNullSafe,
     required String dartLanguageVersion,
-    required List<String> enabledExperiments,
     required File dependenciesFile,
     required LogFunction log,
   })  : _dartSdkPath = sdk.dartSdkPath,
         _flutterToolPath = sdk.flutterToolPath,
         _isNullSafe = isNullSafe,
         _dartLanguageVersion = dartLanguageVersion,
-        _enabledExperiments = enabledExperiments,
         _dependenciesFile = dependenciesFile,
         _log = log;
 
@@ -64,17 +60,11 @@ class ProjectCreator {
     await _runDartPubGet(projectDirectory);
     File(path.join(projectPath, 'analysis_options.yaml')).writeAsStringSync('''
 include: package:lints/recommended.yaml
-analyzer:
-  enable-experiment:
-$_enabledExperimentsYaml
 linter:
   rules:
     avoid_print: false
 ''');
   }
-
-  String get _enabledExperimentsYaml =>
-      _enabledExperiments.map((e) => '    - $e').join('\n');
 
   /// Builds a Flutter project template directory, complete with `pubspec.yaml`,
   /// `analysis_options.yaml`, and `web/index.html`.

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -85,7 +85,7 @@ class DownloadingSdkManager {
 
   static const String _flutterSdkConfigFile = 'flutter-sdk-version.yaml';
 
-  /// Read and return the Flutter sdk configuration file info
+  /// Read and return the Flutter SDK configuration file info
   /// (`flutter-sdk-version.yaml`).
   static String _readFlutterVersion(String channelName) {
     final file = File(path.join(Directory.current.path, _flutterSdkConfigFile));
@@ -93,14 +93,20 @@ class DownloadingSdkManager {
         (loadYaml(file.readAsStringSync()) as Map).cast<String, Object>();
 
     if (!sdkConfig.containsKey('flutter_sdk')) {
-      throw "No key 'flutter_sdk' found in '$_flutterSdkConfigFile'";
+      throw StateError(
+          "No key 'flutter_sdk' found in '$_flutterSdkConfigFile'");
     }
     final flutterConfig = sdkConfig['flutter_sdk'] as Map;
-    final versionKey = '${channelName}_version';
-    if (!flutterConfig.containsKey(versionKey)) {
-      throw "No key '$versionKey' found in '$_flutterSdkConfigFile'";
+    if (!flutterConfig.containsKey(channelName)) {
+      throw StateError(
+          "No key '$channelName' found in '$_flutterSdkConfigFile'");
     }
-    return flutterConfig[versionKey] as String;
+    final channelConfig = flutterConfig[channelName] as Map;
+    if (!channelConfig.containsKey('flutter_version')) {
+      throw StateError(
+          "No key 'flutter_version' found in '$_flutterSdkConfigFile'");
+    }
+    return channelConfig['flutter_version'] as String;
   }
 
   /// Creates a Flutter SDK in `flutter-sdks/` that is configured using the

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -79,34 +79,8 @@ class DownloadingSdkManager {
     if (!channels.contains(channel)) {
       throw StateError('Unknown channel name: $channel');
     }
-    final flutterVersion = _readFlutterVersion(channel);
+    final flutterVersion = readVersionMap(channel)['flutter_version']!;
     return DownloadingSdkManager._(channel, flutterVersion);
-  }
-
-  static const String _flutterSdkConfigFile = 'flutter-sdk-version.yaml';
-
-  /// Read and return the Flutter SDK configuration file info
-  /// (`flutter-sdk-version.yaml`).
-  static String _readFlutterVersion(String channelName) {
-    final file = File(path.join(Directory.current.path, _flutterSdkConfigFile));
-    final sdkConfig =
-        (loadYaml(file.readAsStringSync()) as Map).cast<String, Object>();
-
-    if (!sdkConfig.containsKey('flutter_sdk')) {
-      throw StateError(
-          "No key 'flutter_sdk' found in '$_flutterSdkConfigFile'");
-    }
-    final flutterConfig = sdkConfig['flutter_sdk'] as Map;
-    if (!flutterConfig.containsKey(channelName)) {
-      throw StateError(
-          "No key '$channelName' found in '$_flutterSdkConfigFile'");
-    }
-    final channelConfig = flutterConfig[channelName] as Map;
-    if (!channelConfig.containsKey('flutter_version')) {
-      throw StateError(
-          "No key 'flutter_version' found in '$_flutterSdkConfigFile'");
-    }
-    return channelConfig['flutter_version'] as String;
   }
 
   /// Creates a Flutter SDK in `flutter-sdks/` that is configured using the
@@ -153,6 +127,37 @@ class DownloadingSdkManager {
     return sdk;
   }
 }
+
+String readDartLanguageVersion(String channelName) =>
+    readVersionMap(channelName)['dart_language_version']!;
+
+/// Read and return the Flutter SDK configuration file info
+/// (`flutter-sdk-version.yaml`).
+Map<String, String> readVersionMap(String channelName) {
+  final file = File(path.join(Directory.current.path, _flutterSdkConfigFile));
+  final sdkConfig =
+      (loadYaml(file.readAsStringSync()) as Map).cast<String, Object>();
+
+  if (!sdkConfig.containsKey('flutter_sdk')) {
+    throw StateError("No key 'flutter_sdk' found in '$_flutterSdkConfigFile'");
+  }
+  final flutterConfig = sdkConfig['flutter_sdk'] as Map;
+  if (!flutterConfig.containsKey(channelName)) {
+    throw StateError("No key '$channelName' found in '$_flutterSdkConfigFile'");
+  }
+  final channelConfig = flutterConfig[channelName] as Map;
+  if (!channelConfig.containsKey('flutter_version')) {
+    throw StateError(
+        "No key 'flutter_version' found in '$_flutterSdkConfigFile'");
+  }
+  if (!channelConfig.containsKey('dart_language_version')) {
+    throw StateError(
+        "No key 'dart_language_version' found in '$_flutterSdkConfigFile'");
+  }
+  return channelConfig.cast<String, String>();
+}
+
+const String _flutterSdkConfigFile = 'flutter-sdk-version.yaml';
 
 class _DownloadedFlutterSdk {
   final String flutterSdkPath;

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -79,7 +79,7 @@ class DownloadingSdkManager {
     if (!channels.contains(channel)) {
       throw StateError('Unknown channel name: $channel');
     }
-    final flutterVersion = readVersionMap(channel)['flutter_version']!;
+    final flutterVersion = _readVersionMap(channel)['flutter_version']!;
     return DownloadingSdkManager._(channel, flutterVersion);
   }
 
@@ -129,11 +129,11 @@ class DownloadingSdkManager {
 }
 
 String readDartLanguageVersion(String channelName) =>
-    readVersionMap(channelName)['dart_language_version']!;
+    _readVersionMap(channelName)['dart_language_version']!;
 
 /// Read and return the Flutter SDK configuration file info
 /// (`flutter-sdk-version.yaml`).
-Map<String, String> readVersionMap(String channelName) {
+Map<String, String> _readVersionMap(String channelName) {
   final file = File(path.join(Directory.current.path, _flutterSdkConfigFile));
   final sdkConfig =
       (loadYaml(file.readAsStringSync()) as Map).cast<String, Object>();

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -79,7 +79,8 @@ class DownloadingSdkManager {
     if (!channels.contains(channel)) {
       throw StateError('Unknown channel name: $channel');
     }
-    final flutterVersion = _readVersionMap(channel)['flutter_version']!;
+    final flutterVersion =
+        _readVersionMap(channel)['flutter_version'] as String;
     return DownloadingSdkManager._(channel, flutterVersion);
   }
 
@@ -129,11 +130,15 @@ class DownloadingSdkManager {
 }
 
 String readDartLanguageVersion(String channelName) =>
-    _readVersionMap(channelName)['dart_language_version']!;
+    _readVersionMap(channelName)['dart_language_version'] as String;
+
+List<String> readEnabledExperiments(String channelName) =>
+    ((_readVersionMap(channelName)['enabled_experiments'] ?? []) as List)
+        .cast<String>();
 
 /// Read and return the Flutter SDK configuration file info
 /// (`flutter-sdk-version.yaml`).
-Map<String, String> _readVersionMap(String channelName) {
+Map<String, Object> _readVersionMap(String channelName) {
   final file = File(path.join(Directory.current.path, _flutterSdkConfigFile));
   final sdkConfig =
       (loadYaml(file.readAsStringSync()) as Map).cast<String, Object>();
@@ -154,7 +159,7 @@ Map<String, String> _readVersionMap(String channelName) {
     throw StateError(
         "No key 'dart_language_version' found in '$_flutterSdkConfigFile'");
   }
-  return channelConfig.cast<String, String>();
+  return channelConfig.cast<String, Object>();
 }
 
 const String _flutterSdkConfigFile = 'flutter-sdk-version.yaml';

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -132,10 +132,6 @@ class DownloadingSdkManager {
 String readDartLanguageVersion(String channelName) =>
     _readVersionMap(channelName)['dart_language_version'] as String;
 
-List<String> readEnabledExperiments(String channelName) =>
-    ((_readVersionMap(channelName)['enabled_experiments'] ?? []) as List)
-        .cast<String>();
-
 /// Read and return the Flutter SDK configuration file info
 /// (`flutter-sdk-version.yaml`).
 Map<String, Object> _readVersionMap(String channelName) {

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -59,7 +59,7 @@ main() {
 void main() => defineTests();
 
 void defineTests() {
-  CommonServerApi? commonServerApi;
+  late CommonServerApi commonServerApi;
   late CommonServerImpl commonServerImpl;
 
   MockContainer container;
@@ -69,35 +69,35 @@ void defineTests() {
     String path,
     dynamic jsonData,
   ) async {
-    assert(commonServerApi != null);
     final uri = Uri.parse('/api/$path');
     final request = MockHttpRequest('POST', uri);
     request.headers.add('content-type', jsonContentType);
     request.add(utf8.encode(json.encode(jsonData)));
     await request.close();
-    await shelf_io.handleRequest(request, commonServerApi!.router);
+    await shelf_io.handleRequest(request, commonServerApi.router);
     return request.response;
   }
 
   Future<MockHttpResponse> sendGetRequest(
     String path,
   ) async {
-    assert(commonServerApi != null);
     final uri = Uri.parse('/api/$path');
     final request = MockHttpRequest('POST', uri);
     request.headers.add('content-type', jsonContentType);
     await request.close();
-    await shelf_io.handleRequest(request, commonServerApi!.router);
+    await shelf_io.handleRequest(request, commonServerApi.router);
     return request.response;
   }
 
   group('CommonServerProto JSON', () {
+    late String channel;
+
     setUp(() async {
       container = MockContainer();
       cache = MockCache();
-      final channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
+      channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
       final sdk = Sdk.create(channel);
-      commonServerImpl = CommonServerImpl(container, cache, sdk, false);
+      commonServerImpl = CommonServerImpl(container, cache, sdk, true);
       commonServerApi = CommonServerApi(commonServerImpl);
       await commonServerImpl.init();
 
@@ -157,9 +157,29 @@ void defineTests() {
       }
     });
 
+    test('analyze code with constructor-tearoffs features', () async {
+      for (final version in versions) {
+        final jsonData = {
+          'source': '''
+void main() {
+  List<int>;
+}
+'''
+        };
+        final response =
+            await sendPostRequest('dartservices/$version/analyze', jsonData);
+        expect(response.statusCode, 200);
+        final data = await response.transform(utf8.decoder).join();
+        expect(json.decode(data), <dynamic, dynamic>{});
+      }
+    },
+        // TODO(srawlins): Change to `channel == old` when Flutter stable has
+        // Dart 2.15.
+        skip: channel != 'beta');
+
     test('analyze counterApp', () async {
       for (final version in versions) {
-        final jsonData = {'source': sampleCodeFlutterCounter};
+        final jsonData = {'source': sampleCodeFlutterCounterNullSafe};
         final response =
             await sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 200);
@@ -172,7 +192,7 @@ void defineTests() {
 
     test('analyze draggableAndPhysicsApp', () async {
       for (final version in versions) {
-        final jsonData = {'source': sampleCodeFlutterDraggableCard};
+        final jsonData = {'source': sampleCodeFlutterDraggableCardNullSafe};
         final response =
             await sendPostRequest('dartservices/$version/analyze', jsonData);
         expect(response.statusCode, 200);

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -90,12 +90,11 @@ void defineTests() {
   }
 
   group('CommonServerProto JSON', () {
-    late String channel;
+    final channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
 
     setUp(() async {
       container = MockContainer();
       cache = MockCache();
-      channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
       final sdk = Sdk.create(channel);
       commonServerImpl = CommonServerImpl(container, cache, sdk, true);
       commonServerApi = CommonServerApi(commonServerImpl);

--- a/test/project_creator_test.dart
+++ b/test/project_creator_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 final channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
+final languageVersion = readDartLanguageVersion(channel);
 
 void main() => defineTests();
 
@@ -23,13 +24,12 @@ void defineTests() {
     await dependenciesFile.create();
     final templatesPath = d.dir('project_templates');
     await templatesPath.create();
-    final sdk = Sdk.create('stable');
+    final sdk = Sdk.create(channel);
     return ProjectCreator(
       sdk,
       templatesPath.io.path,
       isNullSafe: true,
       dartLanguageVersion: readDartLanguageVersion(channel),
-      enabledExperiments: readEnabledExperiments(channel),
       dependenciesFile: dependenciesFile.io,
       log: (_) {},
     );
@@ -54,7 +54,7 @@ void defineTests() {
           d.file(
               'pubspec.yaml',
               allOf([
-                matches("sdk: '>=2.14.0 <3.0.0'"),
+                matches("sdk: '>=$languageVersion <3.0.0'"),
                 matches('meta: 1.7.0'),
               ])),
         ]),
@@ -93,7 +93,6 @@ void defineTests() {
         templatesPath.io.path,
         isNullSafe: false,
         dartLanguageVersion: readDartLanguageVersion(channel),
-        enabledExperiments: readEnabledExperiments(channel),
         dependenciesFile: dependenciesFile.io,
         log: (_) {},
       );
@@ -151,7 +150,7 @@ void defineTests() {
           d.file(
               'pubspec.yaml',
               allOf([
-                matches("sdk: '>=2.14.0 <3.0.0'"),
+                matches("sdk: '>=$languageVersion <3.0.0'"),
                 matches('meta: 1.7.0'),
                 matches('sdk: flutter'),
               ])),
@@ -213,7 +212,7 @@ void defineTests() {
           d.file(
               'pubspec.yaml',
               allOf([
-                matches("sdk: '>=2.14.0 <3.0.0'"),
+                matches("sdk: '>=$languageVersion <3.0.0'"),
                 matches('meta: 1.7.0'),
                 matches('sdk: flutter'),
               ])),
@@ -285,7 +284,7 @@ void defineTests() {
           d.file(
               'pubspec.yaml',
               allOf([
-                matches("sdk: '>=2.14.0 <3.0.0'"),
+                matches("sdk: '>=$languageVersion <3.0.0'"),
                 matches('meta: 1.7.0'),
                 matches('sdk: flutter'),
               ])),

--- a/test/project_creator_test.dart
+++ b/test/project_creator_test.dart
@@ -29,6 +29,7 @@ void defineTests() {
       templatesPath.io.path,
       isNullSafe: true,
       dartLanguageVersion: readDartLanguageVersion(channel),
+      enabledExperiments: readEnabledExperiments(channel),
       dependenciesFile: dependenciesFile.io,
       log: (_) {},
     );
@@ -92,6 +93,7 @@ void defineTests() {
         templatesPath.io.path,
         isNullSafe: false,
         dartLanguageVersion: readDartLanguageVersion(channel),
+        enabledExperiments: readEnabledExperiments(channel),
         dependenciesFile: dependenciesFile.io,
         log: (_) {},
       );

--- a/test/project_creator_test.dart
+++ b/test/project_creator_test.dart
@@ -28,6 +28,7 @@ void defineTests() {
       sdk,
       templatesPath.io.path,
       isNullSafe: true,
+      dartLanguageVersion: readDartLanguageVersion(channel),
       dependenciesFile: dependenciesFile.io,
       log: (_) {},
     );
@@ -90,6 +91,7 @@ void defineTests() {
         sdk,
         templatesPath.io.path,
         isNullSafe: false,
+        dartLanguageVersion: readDartLanguageVersion(channel),
         dependenciesFile: dependenciesFile.io,
         log: (_) {},
       );

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -164,6 +164,7 @@ void buildProjectTemplates() async {
       sdk,
       templatesPath,
       isNullSafe: nullSafety,
+      dartLanguageVersion: readDartLanguageVersion(_channel),
       dependenciesFile: _pubDependenciesFile(channel: _channel),
       log: log,
     );
@@ -210,6 +211,7 @@ Future<String> _buildStorageArtifacts(Directory dir, Sdk sdk,
   final pubspec = createPubspec(
     includeFlutterWeb: true,
     nullSafety: nullSafety,
+    dartLanguageVersion: readDartLanguageVersion(_channel),
     dependencies: parsePubDependenciesFile(dependenciesFile: dependenciesFile),
   );
   joinFile(dir, ['pubspec.yaml']).writeAsStringSync(pubspec);
@@ -425,6 +427,7 @@ Future<void> _updateDependenciesFile({
   final pubspec = createPubspec(
     includeFlutterWeb: true,
     nullSafety: true,
+    dartLanguageVersion: readDartLanguageVersion(_channel),
     dependencies: {
       // pkg:lints and pkg:flutter_lints
       'lints': 'any',

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -165,6 +165,7 @@ void buildProjectTemplates() async {
       templatesPath,
       isNullSafe: nullSafety,
       dartLanguageVersion: readDartLanguageVersion(_channel),
+      enabledExperiments: readEnabledExperiments(_channel),
       dependenciesFile: _pubDependenciesFile(channel: _channel),
       log: log,
     );

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -165,7 +165,6 @@ void buildProjectTemplates() async {
       templatesPath,
       isNullSafe: nullSafety,
       dartLanguageVersion: readDartLanguageVersion(_channel),
-      enabledExperiments: readEnabledExperiments(_channel),
       dependenciesFile: _pubDependenciesFile(channel: _channel),
       log: log,
     );


### PR DESCRIPTION
fixes: https://github.com/dart-lang/dart-pad/issues/2074

Add a Dart Language Version field to the flutter-sdk-version.yaml format.

Bump the language version in beta and dev to 2.15.0-0, which enables constructor-tearoffs.

Flip common_server_api_test.dart to run everything null safe.