### PR TITLE
Improve compiler and analysis_server test quality

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -980,16 +980,6 @@ void main() {
 }
 ''';
 
-const sampleStrongError = """
-void main() {
-  foo('whoops');
-}
-
-void foo(int i) {
-  print(i);
-}
-""";
-
 const sampleDart2Error = '''
 class Foo {
   final bool isAlwaysNull;

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -16,6 +16,16 @@ void main() => defineTests();
 void defineTests() {
   late Compiler compiler;
 
+  Future<void> Function() generateCompilerDDCTest(String sample) => () async {
+        final result = await compiler.compileDDC(sample);
+        expect(result.problems, isEmpty);
+        expect(result.success, true);
+        expect(result.compiledJS, isNotEmpty);
+        expect(result.modulesBaseUrl, isNotEmpty);
+
+        expect(result.compiledJS, contains("define('dartpad_main', ["));
+      };
+
   for (final nullSafety in [false, true]) {
     group('Null ${nullSafety ? 'Safe' : 'Unsafe'} Compiler', () {
       setUpAll(() async {
@@ -32,69 +42,59 @@ void defineTests() {
       test('simple', () async {
         final result = await compiler.compile(sampleCode);
 
+        expect(result.problems, isEmpty);
         expect(result.success, true);
         expect(result.compiledJS, isNotEmpty);
         expect(result.sourceMap, isNull);
       });
 
-      Future<void> Function() _generateCompilerDDCTest(String sample) =>
-          () async {
-            final result = await compiler.compileDDC(sample);
-
-            expect(result.success, true);
-            expect(result.compiledJS, isNotEmpty);
-            expect(result.modulesBaseUrl, isNotEmpty);
-
-            expect(result.compiledJS, contains("define('dartpad_main', ["));
-          };
-
       test(
         'compileDDC simple',
-        _generateCompilerDDCTest(sampleCode),
+        generateCompilerDDCTest(sampleCode),
       );
 
       test(
         'compileDDC with web',
-        _generateCompilerDDCTest(
+        generateCompilerDDCTest(
             nullSafety ? sampleCodeWebNullSafe : sampleCodeWeb),
       );
 
       test(
         'compileDDC with Flutter',
-        _generateCompilerDDCTest(sampleCodeFlutter),
+        generateCompilerDDCTest(sampleCodeFlutter),
       );
 
       test(
         'compileDDC with Flutter Counter',
-        _generateCompilerDDCTest(nullSafety
+        generateCompilerDDCTest(nullSafety
             ? sampleCodeFlutterCounterNullSafe
             : sampleCodeFlutterCounter),
       );
 
       test(
         'compileDDC with Flutter Sunflower',
-        _generateCompilerDDCTest(nullSafety
+        generateCompilerDDCTest(nullSafety
             ? sampleCodeFlutterSunflowerNullSafe
             : sampleCodeFlutterSunflower),
       );
 
       test(
         'compileDDC with Flutter Draggable Card',
-        _generateCompilerDDCTest(nullSafety
+        generateCompilerDDCTest(nullSafety
             ? sampleCodeFlutterDraggableCardNullSafe
             : sampleCodeFlutterDraggableCard),
       );
 
       test(
         'compileDDC with Flutter Implicit Animations',
-        _generateCompilerDDCTest(nullSafety
+        generateCompilerDDCTest(nullSafety
             ? sampleCodeFlutterImplicitAnimationsNullSafe
             : sampleCodeFlutterImplicitAnimations),
       );
 
       test(
         'compileDDC with async',
-        _generateCompilerDDCTest(
+        generateCompilerDDCTest(
             nullSafety ? sampleCodeAsyncNullSafe : sampleCodeAsync),
       );
 
@@ -213,11 +213,6 @@ import 'dart:foo';
 void main() { print ('foo'); }
 ''';
         final result = await compiler.compile(code);
-        expect(result.problems.length, 1);
-      });
-
-      test('errors for dart 2', () async {
-        final result = await compiler.compile(sampleDart2Error);
         expect(result.problems.length, 1);
       });
     });


### PR DESCRIPTION
* Add `expect(result.problems, isEmpty);` so that tests fail with a possibly useful message, "expected empty but contained all of this stuff!"
* I don't think the "strong mode" tests or the "dart 2" tests are meaningful.
* Rename local function without leading `_`.