### PR TITLE
Tidy analysis_options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,21 +6,19 @@ analyzer:
   strong-mode:
     implicit-casts: false
   exclude:
-    - dart-sdk/**
     - doc/generated/**
     - flutter-sdks/**
-    - project_templates/**
     # TODO(https://github.com/dart-lang/dart-pad/issues/1712): This seems to be
     # hiding ~2 dozen legitimate analysis issues.
     - lib/src/protos/**
     - local_pub_cache/**
+    - project_templates/**
 
 linter:
   rules:
     - always_declare_return_types
     - avoid_dynamic_calls
     - directives_ordering
-    - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
     - prefer_relative_imports


### PR DESCRIPTION
* We don't make a directory named dart-sdk anymore.
* prefer_final_fields is included in package:lints
* sort