### PR TITLE
Ensure minimum version numbers for some packages

### DIFF
--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -75,7 +75,7 @@ const Set<String> firebasePackages = {
   ...registerableFirebasePackages,
 };
 
-/// The set of packages which indicate that Flutter Web is being used.
+/// The set of supported Flutter-oriented packages.
 const Set<String> supportedFlutterPackages = {
   'flutter_bloc',
   'flutter_hooks',

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -407,12 +407,13 @@ Future<void> _updateDependenciesFile({
     includeFlutterWeb: true,
     dartLanguageVersion: readDartLanguageVersion(_channel),
     dependencies: {
-      // pkg:lints and pkg:flutter_lints
       'lints': 'any',
       'flutter_lints': 'any',
       for (var package in firebasePackages) package: 'any',
       for (var package in supportedFlutterPackages) package: 'any',
       for (var package in supportedBasicDartPackages) package: 'any',
+      // Overwrite with important constraints:
+      ..._packageVersionConstraints,
     },
   );
   joinFile(tempDir, ['pubspec.yaml']).writeAsStringSync(pubspec);
@@ -422,6 +423,14 @@ Future<void> _updateDependenciesFile({
   _pubDependenciesFile(channel: channel)
       .writeAsStringSync(_jsonEncoder.convert(packageVersions));
 }
+
+/// A mapping of version constraints for certain packages.
+const _packageVersionConstraints = {
+  // Ensure that pub version solving keeps these at sane minimum versions.
+  'cloud_firestore': '^3.1.0',
+  'firebase_auth': '^3.3.0',
+  'firebase_core': '^1.10.0',
+};
 
 /// An encoder which indents nested elements by two spaces.
 const JsonEncoder _jsonEncoder = JsonEncoder.withIndent('  ');


### PR DESCRIPTION
I've seen non-deterministic behavior from `flutter packages get`, but this minimum version guard seems to fix the issue.