### PR TITLE
Use minimum package versions in tests too

### DIFF
--- a/lib/src/project_creator.dart
+++ b/lib/src/project_creator.dart
@@ -141,9 +141,19 @@ linter:
         parsePubDependenciesFile(dependenciesFile: _dependenciesFile);
     return {
       for (var package in packages) package: allVersions[package] ?? 'any',
+      // Overwrite with important constraints:
+      ...packageVersionConstraints,
     };
   }
 }
+
+/// A mapping of version constraints for certain packages.
+const packageVersionConstraints = {
+  // Ensure that pub version solving keeps these at sane minimum versions.
+  'cloud_firestore': '^3.1.0',
+  'firebase_auth': '^3.3.0',
+  'firebase_core': '^1.10.0',
+};
 
 /// Parses [dependenciesFile] as a JSON Map of Strings.
 Map<String, String> parsePubDependenciesFile({required File dependenciesFile}) {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -413,7 +413,7 @@ Future<void> _updateDependenciesFile({
       for (var package in supportedFlutterPackages) package: 'any',
       for (var package in supportedBasicDartPackages) package: 'any',
       // Overwrite with important constraints:
-      ..._packageVersionConstraints,
+      ...packageVersionConstraints,
     },
   );
   joinFile(tempDir, ['pubspec.yaml']).writeAsStringSync(pubspec);
@@ -423,14 +423,6 @@ Future<void> _updateDependenciesFile({
   _pubDependenciesFile(channel: channel)
       .writeAsStringSync(_jsonEncoder.convert(packageVersions));
 }
-
-/// A mapping of version constraints for certain packages.
-const _packageVersionConstraints = {
-  // Ensure that pub version solving keeps these at sane minimum versions.
-  'cloud_firestore': '^3.1.0',
-  'firebase_auth': '^3.3.0',
-  'firebase_core': '^1.10.0',
-};
 
 /// An encoder which indents nested elements by two spaces.
 const JsonEncoder _jsonEncoder = JsonEncoder.withIndent('  ');


### PR DESCRIPTION
The tests that were failing were also resolving ancient package versions. This corrects that.

Fixes https://github.com/dart-lang/dart-pad/issues/2133