### PR TITLE
Remove now removed web_sql from allowed imports

### DIFF
--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -143,7 +143,6 @@ const Set<String> _allowedDartImports = {
   'dart:svg',
   'dart:web_audio',
   'dart:web_gl',
-  'dart:web_sql',
   'dart:ui',
 };
 


### PR DESCRIPTION
`dart:web_sql` was removed from the SDK in Dart 2.15.