### PR TITLE
Move some packages to only supporting Flutter

### DIFF
--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -81,6 +81,7 @@ Set<String> supportedFlutterPackages({required bool devMode}) => {
       'flutter_hooks',
       'flutter_lints',
       'flutter_riverpod',
+      'google_fonts',
       'hooks_riverpod',
       if (devMode) ...[
         'english_words',
@@ -112,7 +113,6 @@ const Set<String> supportedBasicDartPackages = {
   'bloc',
   'characters',
   'collection',
-  'google_fonts',
   'http',
   'intl',
   'js',

--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -83,6 +83,7 @@ Set<String> supportedFlutterPackages({required bool devMode}) => {
       'flutter_riverpod',
       'google_fonts',
       'hooks_riverpod',
+      'provider',
       if (devMode) ...[
         'english_words',
         'firebase_analytics',
@@ -120,7 +121,6 @@ const Set<String> supportedBasicDartPackages = {
   'meta',
   'path',
   'pedantic',
-  'provider',
   'riverpod',
   'vector_math',
 };


### PR DESCRIPTION
This removes two of the problematic packages causing https://github.com/dart-lang/dart-pad/issues/2171, but it seems the included Firebase packages also cause issues. Those might require some larger adjustments.