### PR TITLE
Remove pedantic from supported packages and imports

### DIFF
--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -119,7 +119,6 @@ const Set<String> supportedBasicDartPackages = {
   'lints',
   'meta',
   'path',
-  'pedantic',
   'provider',
   'riverpod',
   'vector_math',

--- a/tool/pub_dependencies_beta.json
+++ b/tool/pub_dependencies_beta.json
@@ -42,7 +42,6 @@
   "path_provider_macos": "2.0.5",
   "path_provider_platform_interface": "2.0.3",
   "path_provider_windows": "2.0.5",
-  "pedantic": "1.11.1",
   "platform": "3.1.0",
   "plugin_platform_interface": "2.1.2",
   "process": "4.2.4",

--- a/tool/pub_dependencies_dev.json
+++ b/tool/pub_dependencies_dev.json
@@ -66,7 +66,6 @@
   "path_provider_platform_interface": "2.0.3",
   "path_provider_windows": "2.0.5",
   "path_to_regexp": "0.4.0",
-  "pedantic": "1.11.1",
   "petitparser": "4.4.0",
   "platform": "3.1.0",
   "plugin_platform_interface": "2.1.2",

--- a/tool/pub_dependencies_old.json
+++ b/tool/pub_dependencies_old.json
@@ -41,7 +41,6 @@
   "path_provider_macos": "2.0.5",
   "path_provider_platform_interface": "2.0.3",
   "path_provider_windows": "2.0.5",
-  "pedantic": "1.11.1",
   "platform": "3.1.0",
   "plugin_platform_interface": "2.1.2",
   "process": "4.2.4",

--- a/tool/pub_dependencies_stable.json
+++ b/tool/pub_dependencies_stable.json
@@ -42,7 +42,6 @@
   "path_provider_macos": "2.0.5",
   "path_provider_platform_interface": "2.0.3",
   "path_provider_windows": "2.0.5",
-  "pedantic": "1.11.1",
   "platform": "3.1.0",
   "plugin_platform_interface": "2.1.2",
   "process": "4.2.4",


### PR DESCRIPTION
This would technically be a breaking change(?) as if a snippet imported it previously, they would get an error now.

Closes https://github.com/dart-lang/dart-pad/issues/2180