### PR TITLE
Use new analyzer strict modes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,9 +2,9 @@ include: package:lints/recommended.yaml
 
 analyzer:
   language:
+    strict-casts: true
+    strict-inference: true
     strict-raw-types: true
-  strong-mode:
-    implicit-casts: false
   exclude:
     - doc/generated/**
     - flutter-sdks/**

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -482,7 +482,7 @@ abstract class AnalysisServerWrapper {
         .timeout(const Duration(seconds: 1))
         // At runtime, it appears that [ServerDomain.shutdown] returns a
         // `Future<Map<dynamic, dynamic>>`.
-        .catchError((_) => {});
+        .catchError((_) => <dynamic, dynamic>{});
   }
 
   /// Internal implementation of the completion mechanism.

--- a/lib/src/server_cache.dart
+++ b/lib/src/server_cache.dart
@@ -121,7 +121,7 @@ class RedisCache implements ServerCache {
             _resetConnection();
             log.warning('$_logPrefix: connection terminated, reconnecting');
             _reconnect();
-          }).catchError((e) {
+          }).catchError((dynamic e) {
             _resetConnection();
             log.warning(
                 '$_logPrefix: connection terminated with error $e, reconnecting');


### PR DESCRIPTION
Enable and use the analyzer's [strict mode language options](https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks) instead of the deprecated strong mode options.