### PR TITLE
Disable experiments until Dart2JS and DDC support the same flags.

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -194,9 +194,8 @@ class Compiler {
         ...['--module-name', 'dartpad_main'],
         '--enable-asserts',
         '--sound-null-safety',
-        if (_sdk.masterChannel)
-          ..._sdk.experiments
-              .map((experiment) => '--enable-experiment=$experiment'),
+        ..._sdk.experiments
+            .map((experiment) => '--enable-experiment=$experiment'),
         bootstrapPath,
         '--packages=${path.join(temp.path, '.dart_tool', 'package_config.json')}',
       ];

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -50,7 +50,8 @@ class Sdk {
 
   // Experiments that this SDK is configured with
   List<String> get experiments {
-    if (masterChannel) return ['records', 'patterns'];
+    // TODO: re-enable once both DDC and Dart2JS support the same experiments
+    // if (masterChannel) return ['records', 'patterns'];
     return [];
   }
 


### PR DESCRIPTION
The difference in experiment support between Dart2JS (straight Dart dartpads) and DartDevCompiler (Flutter dartpads) is causing too much confusion.

Re-enable experiments once Dart2JS and DartDevCompiler support the same experiment flags.