### PR TITLE
Cleanup library directive usage

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,10 +18,13 @@ linter:
   rules:
     - always_declare_return_types
     - avoid_dynamic_calls
+    - dangling_library_doc_comments
     - directives_ordering
+    - library_annotations
     - prefer_final_in_for_each
     - prefer_final_locals
     - prefer_relative_imports
     - prefer_single_quotes
     - sort_pub_dependencies
     - unawaited_futures
+    - unnecessary_library_directive

--- a/benchmark/bench.dart
+++ b/benchmark/bench.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.bench;
-
 import 'dart:async';
 
 import 'package:dart_services/src/analysis_server.dart';

--- a/bin/server_cloud_run.dart
+++ b/bin/server_cloud_run.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A dev-time only server; see `bin/server.dart` for the GAE server.
-library services.bin;
+library;
 
 import 'dart:async';
 

--- a/bin/server_dev.dart
+++ b/bin/server_dev.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A dev-time only server; see `bin/server.dart` for the GAE server.
-library services.bin;
+library;
 
 import 'dart:async';
 

--- a/example/web/index.dart
+++ b/example/web/index.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services_server.apitest;
-
 import 'dart:convert';
 import 'dart:html';
 import 'package:codemirror/codemirror.dart';

--- a/example/web/services_utils.dart
+++ b/example/web/services_utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library dartservices_modules;
-
 import 'dart:async';
 
 import 'package:http/browser_client.dart';

--- a/lib/services_cloud_run.dart
+++ b/lib/services_cloud_run.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A server for Cloud Run.
-library services_cloud_run;
+library;
 
 import 'dart:async';
 import 'dart:io';

--- a/lib/services_dev.dart
+++ b/lib/services_dev.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A dev-time only server.
-library services_dev;
+library;
 
 import 'dart:async';
 import 'dart:io';

--- a/lib/src/analysis_server.dart
+++ b/lib/src/analysis_server.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A wrapper around an analysis server instance
-library services.analysis_server;
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/lib/src/analysis_servers.dart
+++ b/lib/src/analysis_servers.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A wrapper around an analysis server instance.
-library services.analysis_servers;
+library;
 
 import 'dart:async';
 import 'dart:io';

--- a/lib/src/bench.dart
+++ b/lib/src/bench.dart
@@ -4,7 +4,7 @@
 
 /// A benchmark library. This library supports running benchmarks which can
 /// run asynchronously.
-library services.bench;
+library;
 
 import 'dart:async';
 import 'dart:convert' show json;

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.common;
-
 import 'dart:io';
 
 const kMainDart = 'main.dart';

--- a/lib/src/common_server_api.dart
+++ b/lib/src/common_server_api.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.common_server_api;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/lib/src/common_server_api.g.dart
+++ b/lib/src/common_server_api.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of services.common_server_api;
+part of 'common_server_api.dart';
 
 // **************************************************************************
 // ShelfRouterGenerator

--- a/lib/src/common_server_impl.dart
+++ b/lib/src/common_server_impl.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.common_server_impl;
-
 import 'dart:async';
 import 'dart:convert';
 

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// This library is a wrapper around the Dart to JavaScript (dart2js) compiler.
-library services.compiler;
+library;
 
 import 'dart:async';
 import 'dart:io';

--- a/lib/src/github_oauth_handler.dart
+++ b/lib/src/github_oauth_handler.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-///
 /// This presents an API for initiating OAuth requests to github and then
 /// redirecting back to the calling Dart-Pad application.
 ///
@@ -14,7 +13,7 @@
 /// return to dart-pad app url should be stored in
 /// K_GITHUB_OAUTH_AUTH_RETURN_URL and K_GITHUB_OAUTH_RETURN_TO_APP_URL
 /// environmental variables respectively.
-///
+library;
 
 import 'dart:convert';
 import 'dart:io';

--- a/lib/src/scheduler.dart
+++ b/lib/src/scheduler.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.scheduler;
-
 import 'dart:async';
 import 'dart:collection';
 

--- a/lib/src/server_cache.dart
+++ b/lib/src/server_cache.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.server_cache;
-
 import 'dart:async';
 import 'dart:math';
 

--- a/lib/src/shelf_cors.dart
+++ b/lib/src/shelf_cors.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library shelf_cors;
-
 import 'dart:async';
 import 'package:shelf/shelf.dart';
 

--- a/test/all.dart
+++ b/test/all.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.all_test;
-
 import 'analysis_server_test.dart' as analysis_server_test;
 import 'bench_test.dart' as bench_test;
 import 'common_server_api_protobuf_test.dart'

--- a/test/analysis_server_test.dart
+++ b/test/analysis_server_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.analyzer_server_test;
-
 import 'dart:io';
 
 import 'package:dart_services/src/analysis_server.dart';

--- a/test/bench_test.dart
+++ b/test/bench_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.bench_test;
-
 import 'dart:async';
 
 import 'package:dart_services/src/bench.dart';

--- a/test/common_server_api_protobuf_test.dart
+++ b/test/common_server_api_protobuf_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.common_server_api_protobuf_test;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/test/common_server_api_test.dart
+++ b/test/common_server_api_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.common_server_api_test;
-
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';

--- a/test/common_test.dart
+++ b/test/common_test.dart
@@ -4,8 +4,6 @@
 
 // ignore_for_file: prefer_single_quotes
 
-library services.common_test;
-
 import 'package:dart_services/src/common.dart';
 import 'package:test/test.dart';
 

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.compiler_test;
-
 import 'dart:io';
 
 import 'package:dart_services/src/common.dart';

--- a/test/flutter_analysis_server_test.dart
+++ b/test/flutter_analysis_server_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.flutter_analyzer_server_test;
-
 import 'dart:io';
 
 import 'package:dart_services/src/analysis_server.dart';

--- a/test/gae_deployed_test.dart
+++ b/test/gae_deployed_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library gae_deployed_test;
-
 import 'package:dart_services/src/common.dart' as common;
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';

--- a/test/integration.dart
+++ b/test/integration.dart
@@ -4,7 +4,7 @@
 
 /// Tests which run as part of integration testing; these test high level
 /// services.
-library services.integration;
+library;
 
 import 'gae_deployed_test.dart' as gae_test_test;
 

--- a/test/redis_cache_test.dart
+++ b/test/redis_cache_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.redis_cache_test;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/tool/fuzz_driver.dart
+++ b/tool/fuzz_driver.dart
@@ -5,8 +5,7 @@
 /// This tool drives the services API with a large number of files and fuzz
 /// test variations. This should be run over all of the co19 tests in the SDK
 /// prior to each deployment of the server.
-
-library services.fuzz_driver;
+library;
 
 import 'dart:async';
 import 'dart:io' as io;

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library services.grind;
-
 import 'dart:async';
 import 'dart:convert' show JsonEncoder;
 import 'dart:io';


### PR DESCRIPTION
There is usually [no need to name libraries](https://dart.dev/guides/language/effective-dart/style#dont-explicitly-name-libraries) and now with Dart 2.19, libraries that have comments or annotations can use an unnamed `library` directive.

- Removes unnecessary library directives
- Removes explicit names from libraries when a library directive is needed
- Add unnamed library directives when library docs were missing one