### PR TITLE
Enable `inline-class` experiment on `master` channel

### DIFF
--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -51,11 +51,10 @@ class Sdk {
   // Which channel is this SDK?
   final String _channel;
 
-  // Experiments that this SDK is configured with
+  /// Experiments that this SDK is configured with
   List<String> get experiments {
-    // Waiting for the next experiment.
-    // if (masterChannel) return ['records', 'patterns'];
-    return [];
+    if (masterChannel) return const ['inline-class'];
+    return const [];
   }
 
   factory Sdk.create(String channel) {


### PR DESCRIPTION
While inline-classes aren't finalized, the basic use of them seems to be working in both DDC and dart2js.

From: https://github.com/dart-lang/sdk/blob/main/tools/experimental_features.yaml#L133

Contributes to https://github.com/dart-lang/dart-pad/issues/2480