### PR TITLE
remove no longer used files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-# Docker should ignore the local copy of Flutter and install its own,
-# since the Docker container is likely running a different OS than the
-# developer's machine.
-flutter-sdk


### PR DESCRIPTION
remove no longer used files:
- `.gitmodules` is empty (it looks like it had previously been used for a flutter submodule)
- `.dockerignore` references a directory that we don't create anymore (it references `flutter-sdk/`, but we now use `flutter-sdks/`). I'm less familiar w/ the docker workflow here but assume that not ignoring flutter-sdks/ isn't currently causing problems

cc @domesticmouse @RedBrogdon 
