### PR TITLE
adjust package creation code of the project_templates

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -138,10 +138,11 @@ class Compiler {
     return compileFilesDDC({kMainDart: source});
   }
 
-  /// Compile the given set of source files and return the
-  /// resulting [DDCCompilationResults].
+  /// Compile the given set of source files and return the resulting
+  /// [DDCCompilationResults].
+  ///
   /// [files] is a map containing the source files in the format
-  ///   `{ "filename1":"sourcecode1" .. "filenameN":"sourcecodeN"}`
+  /// `{ "filename1":"sourcecode1" ... "filenameN":"sourcecodeN"}`.
   Future<DDCCompilationResults> compileFilesDDC(
       Map<String, String> files) async {
     if (files.isEmpty) {


### PR DESCRIPTION
Adjust package creation code of the project_templates:
- ensure that a failing `pub get` when populating the project templates will fail the grind script (propagate the failure)
- don't add flutter specific packages to the dart project template

 I noticed that the grind script to set up the repo wasn't working for me; the pub get was failing (silently) because a few flutter specific packages were being added to the pubspec for the dart project template. This PR addresses both issues.

Separately, It doesn't look like we actually need a separate project template for the flutter firebase code path? We could just combine that template w/ the regular flutter one.
