### PR TITLE
Use Dart language version as lower bound

### DIFF
--- a/lib/src/project_creator.dart
+++ b/lib/src/project_creator.dart
@@ -17,7 +17,7 @@ class ProjectCreator {
 
   final String _templatesPath;
 
-  /// The Dart Language Version to use for code using null safety.
+  /// The Dart language version to use.
   final String _dartLanguageVersion;
 
   final File _dependenciesFile;
@@ -220,7 +220,7 @@ String createPubspec({
   var content = '''
 name: dartpad_sample
 environment:
-  sdk: $dartLanguageVersion
+  sdk: ^$dartLanguageVersion
 dependencies:
 ''';
 

--- a/test/project_creator_test.dart
+++ b/test/project_creator_test.dart
@@ -51,7 +51,7 @@ void defineTests() {
           d.file(
             'pubspec.yaml',
             allOf([
-              matches('sdk: $languageVersion'),
+              matches('sdk: ^$languageVersion'),
             ]),
           ),
         ]),
@@ -103,7 +103,7 @@ void defineTests() {
           d.file(
             'pubspec.yaml',
             allOf([
-              matches('sdk: $languageVersion'),
+              matches('sdk: ^$languageVersion'),
               matches('sdk: flutter'),
             ]),
           ),
@@ -167,7 +167,7 @@ void defineTests() {
           d.file(
             'pubspec.yaml',
             allOf([
-              matches('sdk: $languageVersion'),
+              matches('sdk: ^$languageVersion'),
               matches('sdk: flutter'),
             ]),
           ),

--- a/test/project_creator_test.dart
+++ b/test/project_creator_test.dart
@@ -51,7 +51,7 @@ void defineTests() {
           d.file(
             'pubspec.yaml',
             allOf([
-              matches('sdk: ^$languageVersion'),
+              contains('sdk: ^$languageVersion'),
             ]),
           ),
         ]),
@@ -103,7 +103,7 @@ void defineTests() {
           d.file(
             'pubspec.yaml',
             allOf([
-              matches('sdk: ^$languageVersion'),
+              contains('sdk: ^$languageVersion'),
               matches('sdk: flutter'),
             ]),
           ),
@@ -167,7 +167,7 @@ void defineTests() {
           d.file(
             'pubspec.yaml',
             allOf([
-              matches('sdk: ^$languageVersion'),
+              contains('sdk: ^$languageVersion'),
               matches('sdk: flutter'),
             ]),
           ),


### PR DESCRIPTION
This works around https://github.com/dart-lang/sdk/issues/52672 which I've seen causing confusion for DartPad users, since it indicates recent APIs are not guaranteed to be supported.

Example: https://dartpad.dev/?id=f685fafbc0699fdeb702002534b8ab6a

Also changes the `matches` to `contains`, since `matches` converts to a regular expression.